### PR TITLE
Add event-level serialization to cesr-ts, refactor keri to use it

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -29,7 +29,7 @@
     "npm:build:all": "deno task build:npm && deno task cesr:build:npm"
   },
   "imports": {
-    "cesr-ts": "npm:cesr-ts@^0.2.3"
+    "cesr-ts": "./packages/cesr/mod.ts"
   },
   "nodeModulesDir": "auto",
   "compilerOptions": {

--- a/deno.lock
+++ b/deno.lock
@@ -23,7 +23,6 @@
     "npm:@types/node@*": "24.2.0",
     "npm:cbor-x@*": "1.6.0",
     "npm:cbor-x@^1.6.0": "1.6.0",
-    "npm:cesr-ts@~0.2.3": "0.2.3",
     "npm:commander@^10.0.1": "10.0.1",
     "npm:effection@^3.6.0": "3.6.1",
     "npm:lmdb@^3.4.4": "3.4.4"
@@ -226,13 +225,6 @@
         "cbor-extract"
       ]
     },
-    "cesr-ts@0.2.3": {
-      "integrity": "sha512-uU3MW2BllOx6eFHBhGKGtazQUKiZ1si9LF90fjYVA5CmnAFH90S21ekXC98q7poB9VcAyqxZIwbY1f8DdinbaA==",
-      "dependencies": [
-        "effection"
-      ],
-      "bin": true
-    },
     "commander@10.0.1": {
       "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
     },
@@ -313,9 +305,6 @@
     }
   },
   "workspace": {
-    "dependencies": [
-      "npm:cesr-ts@~0.2.3"
-    ],
     "members": {
       "packages/cesr": {
         "dependencies": [
@@ -329,7 +318,6 @@
         "dependencies": [
           "jsr:@deno/dnt@~0.42.3",
           "jsr:@std/assert@0.217",
-          "npm:cesr-ts@~0.2.3",
           "npm:commander@^10.0.1",
           "npm:effection@^3.6.0",
           "npm:lmdb@^3.4.4"

--- a/packages/cesr/src/core/errors.ts
+++ b/packages/cesr/src/core/errors.ts
@@ -24,6 +24,7 @@ export class VersionError extends ParserError {}
 export class UnknownCodeError extends ParserError {}
 export class GroupSizeError extends ParserError {}
 export class DeserializeError extends ParserError {}
+export class SerializeError extends ParserError {}
 /** Failure while constructing syntax artifacts from token bytes. */
 export class SyntaxParseError extends ParserError {
   constructor(

--- a/packages/cesr/src/index.ts
+++ b/packages/cesr/src/index.ts
@@ -8,6 +8,7 @@ export * from "./parser/group-dispatch.ts";
 export * from "./serder/smell.ts";
 export * from "./serder/serder.ts";
 export * from "./serder/serdery.ts";
+export * from "./serder/saidify.ts";
 export * from "./primitives/matter.ts";
 export * from "./primitives/counter.ts";
 export * from "./primitives/indexer.ts";

--- a/packages/cesr/src/serder/saidify.ts
+++ b/packages/cesr/src/serder/saidify.ts
@@ -1,0 +1,83 @@
+import { MATTER_SIZES } from "../tables/matter.tables.generated.ts";
+import { SerializeError } from "../core/errors.ts";
+import { Matter } from "../primitives/matter.ts";
+import { versify } from "./smell.ts";
+import { serializeBody } from "./serder.ts";
+import type { Kind, Protocol } from "../tables/versions.ts";
+import type { Versionage } from "../tables/table-types.ts";
+import { Vrsn_1_0 } from "../tables/versions.ts";
+
+/** Caller-provided hash function (e.g. blake3). */
+export type HashFn = (data: Uint8Array) => Uint8Array;
+
+export interface SaidifyResult {
+  ked: Record<string, unknown>;
+  raw: Uint8Array;
+  said: string;
+}
+
+/**
+ * Computes the Self-Addressing Identifier (SAID) for a key event dictionary.
+ *
+ * cesr-ts stays crypto-free: the hash function is supplied by the caller.
+ */
+export function saidify(
+  ked: Record<string, unknown>,
+  hashFn: HashFn,
+  opts?: {
+    field?: string;
+    code?: string;
+    kind?: Kind;
+    proto?: Protocol;
+    pvrsn?: Versionage;
+  },
+): SaidifyResult {
+  const field = opts?.field ?? "d";
+  const code = opts?.code ?? "E";
+  const kind = opts?.kind ?? "JSON";
+  const proto = opts?.proto ?? "KERI";
+  const pvrsn = opts?.pvrsn ?? Vrsn_1_0;
+
+  const sizage = MATTER_SIZES.get(code);
+  if (!sizage) {
+    throw new SerializeError(`Unknown matter code: ${code}`);
+  }
+  if (sizage.fs === null) {
+    throw new SerializeError(
+      `Variable-size code ${code} not supported for saidify`,
+    );
+  }
+
+  const clone = { ...ked };
+  const placeholder = "#".repeat(sizage.fs);
+  clone[field] = placeholder;
+
+  // If the ked also uses the SAID as the identifier, placeholder that too
+  if (field === "d" && ked.i === ked.d) {
+    clone.i = placeholder;
+  }
+
+  // Update version string with measured size if `v` field exists
+  if (typeof clone.v === "string") {
+    const measured = serializeBody(clone, kind);
+    clone.v = versify({ proto, pvrsn, kind, size: measured.length });
+  }
+
+  const raw = serializeBody(clone, kind);
+  const digest = hashFn(raw);
+  const said = new Matter({ code, raw: digest }).qb64;
+
+  clone[field] = said;
+  if (field === "d" && ked.i === ked.d) {
+    clone.i = said;
+  }
+
+  // Re-serialize with final SAID and correct version size
+  if (typeof clone.v === "string") {
+    const finalRaw = serializeBody(clone, kind);
+    clone.v = versify({ proto, pvrsn, kind, size: finalRaw.length });
+  }
+  const finalRaw = serializeBody(clone, kind);
+
+  return { ked: clone, raw: finalRaw, said };
+}

--- a/packages/cesr/src/serder/serder.ts
+++ b/packages/cesr/src/serder/serder.ts
@@ -1,7 +1,8 @@
 import type { CesrBody, CesrMessage, Smellage } from "../core/types.ts";
-import { DeserializeError } from "../core/errors.ts";
-import { decode as decodeMsgpack } from "@msgpack/msgpack";
+import { DeserializeError, SerializeError } from "../core/errors.ts";
+import { decode as decodeMsgpack, encode as encodeMsgpack } from "@msgpack/msgpack";
 import { decode as decodeCbor } from "cbor-x/decode";
+import { encode as encodeCbor } from "cbor-x/encode";
 import { Aggor, isAggorCode } from "../primitives/aggor.ts";
 import { Blinder, isBlinderCode } from "../primitives/blinder.ts";
 import { Mediar, isMediarCode } from "../primitives/mediar.ts";
@@ -12,7 +13,27 @@ import {
   isPrimitiveTuple,
 } from "../primitives/primitive.ts";
 import { Sealer, isSealerCode } from "../primitives/sealer.ts";
-import { Protocols } from "../tables/versions.ts";
+import { type Kind, Protocols } from "../tables/versions.ts";
+
+/**
+ * Serializes a key event dictionary into raw bytes.
+ * Complement of {@link parseSerder}.
+ */
+export function serializeBody(
+  ked: Record<string, unknown>,
+  kind: Kind,
+): Uint8Array {
+  if (kind === "JSON") {
+    return new TextEncoder().encode(JSON.stringify(ked));
+  }
+  if (kind === "CBOR") {
+    return new Uint8Array(encodeCbor(ked));
+  }
+  if (kind === "MGPK") {
+    return new Uint8Array(encodeMsgpack(ked));
+  }
+  throw new SerializeError(`Unsupported serialization kind: ${kind}`);
+}
 
 function normalizeDecodedMap(
   value: unknown,

--- a/packages/cesr/src/serder/smell.ts
+++ b/packages/cesr/src/serder/smell.ts
@@ -1,6 +1,9 @@
-import { b64ToInt } from "../core/bytes.ts";
+import { b64ToInt, intToB64 } from "../core/bytes.ts";
 import { ShortageError, VersionError } from "../core/errors.ts";
 import type { Smellage } from "../core/types.ts";
+import type { Kind, Protocol } from "../tables/versions.ts";
+import type { Versionage } from "../tables/table-types.ts";
+import { Vrsn_1_0 } from "../tables/versions.ts";
 
 // KERIpy parity: allow version token to begin within the first 12 bytes.
 const MAXVSOFFSET = 12;
@@ -8,6 +11,35 @@ const VER1 =
   /(?<proto1>[A-Z]{4})(?<major1>[0-9a-f])(?<minor1>[0-9a-f])(?<kind1>[A-Z]{4})(?<size1>[0-9a-f]{6})_/;
 const VER2 =
   /(?<proto2>[A-Z]{4})(?<pmajor2>[A-Za-z0-9_-])(?<pminor2>[A-Za-z0-9_-]{2})(?<gmajor2>[A-Za-z0-9_-])(?<gminor2>[A-Za-z0-9_-]{2})(?<kind2>[A-Z]{4})(?<size2>[A-Za-z0-9_-]{4})\./;
+
+/**
+ * Builds a CESR version string from its constituent parts.
+ * Complement of {@link smell}.
+ */
+export function versify(opts: {
+  proto?: Protocol;
+  pvrsn?: Versionage;
+  gvrsn?: Versionage | null;
+  kind?: Kind;
+  size: number;
+}): string {
+  const {
+    proto = "KERI",
+    pvrsn = Vrsn_1_0,
+    gvrsn = null,
+    kind = "JSON",
+    size,
+  } = opts;
+
+  if (pvrsn.major === 1) {
+    const hex = size.toString(16).padStart(6, "0");
+    return `${proto}${pvrsn.major.toString(16)}${pvrsn.minor.toString(16)}${kind}${hex}_`;
+  }
+
+  // V2 format
+  const gv = gvrsn ?? { major: 0, minor: 0 };
+  return `${proto}${intToB64(pvrsn.major, 1)}${intToB64(pvrsn.minor, 2)}${intToB64(gv.major, 1)}${intToB64(gv.minor, 2)}${kind}${intToB64(size, 4)}.`;
+}
 
 function byteWindowToText(raw: Uint8Array): string {
   const out: string[] = [];

--- a/packages/cesr/test/unit/saidify.test.ts
+++ b/packages/cesr/test/unit/saidify.test.ts
@@ -1,0 +1,119 @@
+import { assertEquals, assertThrows } from "jsr:@std/assert";
+import { saidify } from "../../src/serder/saidify.ts";
+import { smell } from "../../src/serder/smell.ts";
+import { parseSerder } from "../../src/serder/serder.ts";
+import { Matter } from "../../src/primitives/matter.ts";
+import { SerializeError } from "../../src/core/errors.ts";
+import { blake3 } from "npm:@noble/hashes@1.8.0/blake3";
+
+Deno.test("saidify: inception KED produces correct SAID", () => {
+  const ked: Record<string, unknown> = {
+    v: "KERI10JSON000000_",
+    t: "icp",
+    d: "",
+    i: "",
+    s: "0",
+    kt: "1",
+    k: ["DAbcdefghijklmnopqrstuvwxyz012345678901234567"],
+    nt: "1",
+    n: ["EAbcdefghijklmnopqrstuvwxyz012345678901234567"],
+    bt: "0",
+    b: [],
+    c: [],
+    a: [],
+  };
+
+  const result = saidify(ked, blake3);
+  assertEquals(result.said.length, 44);
+  assertEquals(result.said[0], "E");
+  assertEquals(result.ked.d, result.said);
+  assertEquals(result.ked.i, result.said);
+
+  // Verify version string has correct size
+  const { smellage } = smell(new TextEncoder().encode(result.ked.v as string));
+  assertEquals(smellage.size, result.raw.length);
+});
+
+Deno.test("saidify: SAID matches manual blake3+Matter encoding", () => {
+  const ked: Record<string, unknown> = {
+    v: "KERI10JSON000000_",
+    t: "icp",
+    d: "",
+    i: "DFixedPrefix0000000000000000000000000000000",
+    s: "0",
+    kt: "1",
+    k: ["DFixedPrefix0000000000000000000000000000000"],
+    nt: "0",
+    n: [],
+    bt: "0",
+    b: [],
+    c: [],
+    a: [],
+  };
+
+  const result = saidify(ked, blake3, { field: "d", code: "E" });
+
+  // Manually compute: placeholder the ked, serialize, hash, encode
+  const clone = { ...ked };
+  clone.d = "#".repeat(44);
+  // Don't placeholder i since it's not equal to d
+  const json = JSON.stringify(clone);
+  // Measure and set version
+  const withVersion = { ...clone };
+  withVersion.v = `KERI10JSON${json.length.toString(16).padStart(6, "0")}_`;
+  const raw2 = new TextEncoder().encode(JSON.stringify(withVersion));
+  const digest = blake3(raw2);
+  const expectedSaid = new Matter({ code: "E", raw: digest }).qb64;
+
+  assertEquals(result.said, expectedSaid);
+});
+
+Deno.test("saidify: round-trip through parseSerder", () => {
+  const ked: Record<string, unknown> = {
+    v: "KERI10JSON000000_",
+    t: "icp",
+    d: "",
+    i: "",
+    s: "0",
+    kt: "1",
+    k: ["DTestKey0000000000000000000000000000000000000"],
+    nt: "0",
+    n: [],
+    bt: "0",
+    b: [],
+    c: [],
+    a: [],
+  };
+
+  const result = saidify(ked, blake3);
+  const { smellage } = smell(result.raw);
+  const body = parseSerder(result.raw, smellage);
+  assertEquals(body.said, result.said);
+});
+
+Deno.test("saidify: variable-size code throws", () => {
+  const ked: Record<string, unknown> = { d: "" };
+  // Code "4A" should be a variable-size code (fs === null)
+  // Use a code that doesn't exist or has null fs
+  assertThrows(
+    () => saidify(ked, blake3, { code: "DOES_NOT_EXIST" }),
+    SerializeError,
+    "Unknown matter code",
+  );
+});
+
+Deno.test("saidify: custom field name", () => {
+  const ked: Record<string, unknown> = {
+    v: "KERI10JSON000000_",
+    t: "rpy",
+    d: "",
+    dt: "2024-01-01T00:00:00.000000+00:00",
+    r: "/loc/scheme",
+    a: { myDigest: "" },
+  };
+
+  // We can saidify a non-standard field at root level
+  const result = saidify(ked, blake3, { field: "d" });
+  assertEquals(result.ked.d, result.said);
+  assertEquals(typeof result.ked.v, "string");
+});

--- a/packages/cesr/test/unit/serialize-body.test.ts
+++ b/packages/cesr/test/unit/serialize-body.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "jsr:@std/assert";
+import { serializeBody } from "../../src/serder/serder.ts";
+import { parseSerder } from "../../src/serder/serder.ts";
+import type { Smellage } from "../../src/core/types.ts";
+import { Vrsn_1_0 } from "../../src/tables/versions.ts";
+
+const sampleKed: Record<string, unknown> = {
+  v: "KERI10JSON000000_",
+  t: "icp",
+  d: "EAbcdefg",
+  i: "EAbcdefg",
+  s: "0",
+};
+
+function makeSmellage(kind: "JSON" | "CBOR" | "MGPK", size: number): Smellage {
+  return {
+    proto: "KERI",
+    pvrsn: Vrsn_1_0,
+    gvrsn: null,
+    kind,
+    size,
+  };
+}
+
+Deno.test("serializeBody: JSON output matches JSON.stringify", () => {
+  const raw = serializeBody(sampleKed, "JSON");
+  const expected = new TextEncoder().encode(JSON.stringify(sampleKed));
+  assertEquals(raw, expected);
+});
+
+Deno.test("serializeBody: JSON round-trip through parseSerder", () => {
+  const raw = serializeBody(sampleKed, "JSON");
+  const body = parseSerder(raw, makeSmellage("JSON", raw.length));
+  assertEquals(body.ked, sampleKed);
+});
+
+Deno.test("serializeBody: CBOR round-trip through parseSerder", () => {
+  const raw = serializeBody(sampleKed, "CBOR");
+  const body = parseSerder(raw, makeSmellage("CBOR", raw.length));
+  assertEquals(body.ked, sampleKed);
+});
+
+Deno.test("serializeBody: MGPK round-trip through parseSerder", () => {
+  const raw = serializeBody(sampleKed, "MGPK");
+  const body = parseSerder(raw, makeSmellage("MGPK", raw.length));
+  assertEquals(body.ked, sampleKed);
+});

--- a/packages/cesr/test/unit/versify.test.ts
+++ b/packages/cesr/test/unit/versify.test.ts
@@ -1,0 +1,61 @@
+import { assertEquals } from "jsr:@std/assert";
+import { smell, versify } from "../../src/serder/smell.ts";
+import { Vrsn_1_0, Vrsn_2_0 } from "../../src/tables/versions.ts";
+
+Deno.test("versify: known V1 vector", () => {
+  const vs = versify({ size: 0x229 });
+  assertEquals(vs, "KERI10JSON000229_");
+});
+
+Deno.test("versify: V1 default options", () => {
+  const vs = versify({ size: 100 });
+  assertEquals(vs, "KERI10JSON000064_");
+});
+
+Deno.test("versify: V1 round-trip through smell", () => {
+  const size = 512;
+  const vs = versify({ proto: "KERI", pvrsn: Vrsn_1_0, kind: "JSON", size });
+  const { smellage } = smell(new TextEncoder().encode(vs));
+  assertEquals(smellage.proto, "KERI");
+  assertEquals(smellage.pvrsn, Vrsn_1_0);
+  assertEquals(smellage.kind, "JSON");
+  assertEquals(smellage.size, size);
+});
+
+Deno.test("versify: V1 CBOR round-trip", () => {
+  const vs = versify({ kind: "CBOR", size: 0x1ff });
+  const { smellage } = smell(new TextEncoder().encode(vs));
+  assertEquals(smellage.kind, "CBOR");
+  assertEquals(smellage.size, 0x1ff);
+});
+
+Deno.test("versify: V1 ACDC protocol", () => {
+  const vs = versify({ proto: "ACDC", size: 300 });
+  const { smellage } = smell(new TextEncoder().encode(vs));
+  assertEquals(smellage.proto, "ACDC");
+  assertEquals(smellage.size, 300);
+});
+
+Deno.test("versify: V2 round-trip", () => {
+  const size = 1024;
+  const vs = versify({
+    proto: "KERI",
+    pvrsn: Vrsn_2_0,
+    gvrsn: { major: 1, minor: 0 },
+    kind: "JSON",
+    size,
+  });
+  const { smellage } = smell(new TextEncoder().encode(vs));
+  assertEquals(smellage.proto, "KERI");
+  assertEquals(smellage.pvrsn, Vrsn_2_0);
+  assertEquals(smellage.gvrsn, { major: 1, minor: 0 });
+  assertEquals(smellage.kind, "JSON");
+  assertEquals(smellage.size, size);
+});
+
+Deno.test("versify: V2 null gvrsn defaults to 0.0", () => {
+  const vs = versify({ pvrsn: Vrsn_2_0, size: 256 });
+  const { smellage } = smell(new TextEncoder().encode(vs));
+  assertEquals(smellage.gvrsn, { major: 0, minor: 0 });
+  assertEquals(smellage.size, 256);
+});

--- a/packages/keri/deno.json
+++ b/packages/keri/deno.json
@@ -27,7 +27,7 @@
     "lmdb": "npm:lmdb@^3.4.4",
     "commander": "npm:commander@^10.0.1",
     "jsr:@std/assert": "jsr:@std/assert@^0.217.0",
-    "cesr-ts": "npm:cesr-ts@^0.2.3"
+    "cesr-ts": "../cesr/mod.ts"
   },
   "compilerOptions": {
     "lib": [

--- a/packages/keri/src/app/habbing.ts
+++ b/packages/keri/src/app/habbing.ts
@@ -1,4 +1,6 @@
+import { blake3 } from "npm:@noble/hashes@1.8.0/blake3";
 import { type Operation } from "npm:effection@^3.6.0";
+import { saidify, serializeBody, versify } from "cesr-ts";
 import { Configer, createConfiger } from "./configing.ts";
 import { Baser, createBaser } from "../db/basing.ts";
 import { createKeeper, Keeper } from "../db/keeping.ts";
@@ -8,7 +10,6 @@ import {
   encodeCounterV1,
   encodeDateTimeToDater,
   encodeHugeNumber,
-  makeSaider,
   Manager,
   normalizeSaltQb64,
   saltySigner,
@@ -67,14 +68,6 @@ export interface KeverState {
   wits: string[];
 }
 
-function versifyV1(size: number): string {
-  return `KERI10JSON${size.toString(16).padStart(6, "0")}_`;
-}
-
-function serializeKed(ked: Record<string, unknown>): Uint8Array {
-  return new TextEncoder().encode(JSON.stringify(ked));
-}
-
 function makeNowIso8601(): string {
   const now = new Date();
   const y = now.getUTCFullYear().toString().padStart(4, "0");
@@ -108,13 +101,12 @@ function makeInceptRaw(
   const ilk = args.delpre ? "dip" : "icp";
   const kt = args.isith ?? defaultThreshold(keys.length, 1);
   const nt = args.nsith ?? defaultThreshold(ndigs.length, 0);
-  const saidDummy = "#".repeat(44);
 
   const ked: Record<string, unknown> = {
-    v: versifyV1(0),
+    v: versify({ size: 0 }),
     t: ilk,
-    d: saidDummy,
-    i: args.code === "E" ? saidDummy : keys[0],
+    d: "",
+    i: args.code === "E" ? "" : keys[0],
     s: "0",
     kt,
     k: keys,
@@ -128,15 +120,9 @@ function makeInceptRaw(
 
   if (args.delpre) ked.di = args.delpre;
 
-  ked.v = versifyV1(serializeKed(ked).length);
-  const sizedDummied = serializeKed(ked);
-  const said = makeSaider(sizedDummied);
+  const result = saidify(ked, blake3, { code: "E" });
 
-  ked.d = said;
-  if (args.code === "E") ked.i = said;
-
-  const raw = serializeKed(ked);
-  return { raw, pre: ked.i as string };
+  return { raw: result.raw, pre: result.ked.i as string };
 }
 
 /** Represents a local identifier habitat and its current key state. */

--- a/packages/keri/src/app/keeping.ts
+++ b/packages/keri/src/app/keeping.ts
@@ -1,11 +1,14 @@
 import { blake3 } from "npm:@noble/hashes@1.8.0/blake3";
 import { argon2id } from "npm:@noble/hashes@1.8.0/argon2";
 import { ed25519 } from "npm:@noble/curves@1.9.7/ed25519";
-import { parseMatter } from "cesr-ts";
+import {
+  decodeB64,
+  Indexer,
+  intToB64,
+  Matter,
+  parseMatter,
+} from "cesr-ts";
 import { Keeper, PrePrm, PreSit } from "../db/keeping.ts";
-
-const B64_ALPHABET =
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
 export enum Algos {
   randy = "randy",
@@ -52,70 +55,13 @@ interface SignerMaterial {
   verferQb64: string;
 }
 
-function toBase64Url(bytes: Uint8Array): string {
-  let s = "";
-  for (const b of bytes) s += String.fromCharCode(b);
-  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
-}
-
-function fromBase64Url(text: string): Uint8Array {
-  const padded = text + "=".repeat((4 - (text.length % 4 || 4)) % 4);
-  const b64 = padded.replace(/-/g, "+").replace(/_/g, "/");
-  const decoded = atob(b64);
-  const out = new Uint8Array(decoded.length);
-  for (let i = 0; i < decoded.length; i++) out[i] = decoded.charCodeAt(i);
-  return out;
-}
-
-function intToB64(value: number, length = 1): string {
-  let v = value;
-  const out = new Array<string>(length).fill("A");
-  for (let i = length - 1; i >= 0; i--) {
-    out[i] = B64_ALPHABET[v & 0x3f];
-    v = Math.floor(v / 64);
-  }
-  return out.join("");
-}
-
 function parseQb64Raw(qb64: string): Uint8Array {
   return parseMatter(new TextEncoder().encode(qb64), "txt").raw;
 }
 
-function encodeFixedMatter(code: string, raw: Uint8Array): string {
-  const cs = code.length;
-  const ps = cs % 4;
-  const body = toBase64Url(
-    new Uint8Array(ps + raw.length).map((_, i) => i < ps ? 0 : raw[i - ps]),
-  );
-  return `${code}${body.slice(ps)}`;
-}
-
-function encodeIndexerEd25519Sig(
-  rawSig: Uint8Array,
-  index: number,
-  ondex = index,
-): string {
-  const code = ondex === index ? "A" : "2A";
-  if (code !== "A") {
-    throw new Error("Only compact single-sig indexer encoding is implemented.");
-  }
-  const both = `${code}${intToB64(index, 1)}`;
-  const ps = (3 - (rawSig.length % 3)) % 3;
-  const body = toBase64Url(
-    new Uint8Array(ps + rawSig.length).map((_, i) =>
-      i < ps ? 0 : rawSig[i - ps]
-    ),
-  );
-  return `${both}${body.slice(ps)}`;
-}
-
-function blake3Qb64(raw: Uint8Array, code = "E"): string {
-  return encodeFixedMatter(code, blake3(raw));
-}
-
 function randomSaltQb64(): string {
   const raw = crypto.getRandomValues(new Uint8Array(16));
-  return encodeFixedMatter("0A", raw);
+  return new Matter({ code: "0A", raw }).qb64;
 }
 
 function pathToBytes(path: string): Uint8Array {
@@ -158,9 +104,9 @@ export function saltySigner(
   temp: boolean,
 ): SignerMaterial {
   const seedRaw = deriveSeedFromSalt(saltQb64, path, tier, temp);
-  const seedQb64 = encodeFixedMatter("A", seedRaw);
+  const seedQb64 = new Matter({ code: "A", raw: seedRaw }).qb64;
   const pubRaw = ed25519.getPublicKey(seedRaw);
-  const verferQb64 = encodeFixedMatter(transferable ? "D" : "B", pubRaw);
+  const verferQb64 = new Matter({ code: transferable ? "D" : "B", raw: pubRaw }).qb64;
   return { seedQb64, verferQb64 };
 }
 
@@ -252,7 +198,7 @@ export class Manager {
         throw new Error("Seed required when aeid is set.");
       }
       const seedRaw = parseQb64Raw(seed);
-      const derivedAeid = encodeFixedMatter("B", ed25519.getPublicKey(seedRaw));
+      const derivedAeid = new Matter({ code: "B", raw: ed25519.getPublicKey(seedRaw) }).qb64;
       if (derivedAeid !== aeid) {
         throw new Error(
           `Seed missing or provided seed not associated with aeid=${aeid}.`,
@@ -316,10 +262,7 @@ export class Manager {
         usedTier,
         temp,
       );
-      const dig = blake3Qb64(
-        new TextEncoder().encode(signer.verferQb64),
-        dcode,
-      );
+      const dig = new Matter({ code: dcode, raw: blake3(new TextEncoder().encode(signer.verferQb64)) }).qb64;
       digers.push({ qb64: dig });
       this.ks.putPris(signer.verferQb64, signer.seedQb64);
     }
@@ -401,14 +344,14 @@ export class Manager {
       const seedRaw = parseQb64Raw(seedQb64);
       const sigRaw = ed25519.sign(ser, seedRaw);
       return indexed
-        ? encodeIndexerEd25519Sig(sigRaw, idx, idx)
-        : encodeFixedMatter("0B", sigRaw);
+        ? new Indexer({ code: "A", raw: sigRaw, index: idx }).qb64
+        : new Matter({ code: "0B", raw: sigRaw }).qb64;
     });
   }
 }
 
 export function normalizeSaltQb64(salt?: string): string {
-  return salt ? encodeFixedMatter("0A", parseQb64Raw(salt)) : randomSaltQb64();
+  return salt ? new Matter({ code: "0A", raw: parseQb64Raw(salt) }).qb64 : randomSaltQb64();
 }
 
 export function branToSaltQb64(bran: string): string {
@@ -435,20 +378,18 @@ export function encodeHugeNumber(num: number): string {
     raw[i] = Number(value & 0xffn);
     value >>= 8n;
   }
-  return encodeFixedMatter("0A", raw);
+  return new Matter({ code: "0A", raw }).qb64;
 }
 
 export function normalizeQb64Code(qb64: string): string {
-  return encodeFixedMatter(
-    parseMatter(new TextEncoder().encode(qb64), "txt").code,
-    parseQb64Raw(qb64),
-  );
+  const m = parseMatter(new TextEncoder().encode(qb64), "txt");
+  return new Matter({ code: m.code, raw: m.raw }).qb64;
 }
 
 export function makeSaider(raw: Uint8Array): string {
-  return blake3Qb64(raw, "E");
+  return new Matter({ code: "E", raw: blake3(raw) }).qb64;
 }
 
 export function b64DecodeUrl(text: string): Uint8Array {
-  return fromBase64Url(text);
+  return decodeB64(text);
 }


### PR DESCRIPTION
## Summary

- **cesr-ts**: Add `versify()`, `serializeBody()`, and `saidify()` — the missing event-level serialization complement to the existing parse/deserialize functions
- **keri**: Replace ~100 lines of reimplemented encoding utilities (`encodeFixedMatter`, `toBase64Url`, `intToB64`, `blake3Qb64`, `makeSaider`, `versifyV1`, `serializeKed`) with imports from cesr-ts (`Matter`, `Indexer`, `versify`, `serializeBody`, `saidify`)
- **deno.json**: Point `cesr-ts` import maps to local package source for monorepo development

Builds on PR #16 (`db-init-incept-rotate`) which added primitive-level encoding.

## Test plan

- [ ] `cd packages/cesr && deno test` — 16 new tests (versify, serializeBody, saidify) plus all existing tests pass
- [ ] `cd packages/keri && deno test --allow-all --unstable-ffi` — all 55 keri tests pass with identical behavior
- [ ] Round-trip: `versify` → `smell`, `serializeBody` → `parseSerder`
- [ ] SAID parity: `saidify` produces same output as keri's previous `makeSaider` on identical input

🤖 Generated with [Claude Code](https://claude.com/claude-code)