### PR TITLE
[codex] Release cesr-ts 0.6.0

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2,6 +2,7 @@
   "version": "5",
   "specifiers": {
     "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
+    "jsr:@deno/dnt@0.42.3": "0.42.3",
     "jsr:@deno/dnt@~0.42.3": "0.42.3",
     "jsr:@std/assert@*": "0.217.0",
     "jsr:@std/assert@0.217": "0.217.0",

--- a/packages/cesr/CHANGELOG.md
+++ b/packages/cesr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # cesr-ts
 
+## 0.6.0
+
+### Minor Changes
+
+- Fix CESR non-native fallback payload handling and normalize parser/runtime surfaces used by KERI delegation interop flows.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/cesr/deno.json
+++ b/packages/cesr/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@keri-ts/cesr",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/cesr/package.json
+++ b/packages/cesr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesr-ts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Monorepo metadata for cesr-ts versioning and release tooling",
   "license": "Apache-2.0",

--- a/packages/cesr/scripts/build_npm.ts
+++ b/packages/cesr/scripts/build_npm.ts
@@ -34,6 +34,7 @@ await build({
   },
   typeCheck: false,
   test: false,
+  skipNpmInstall: true,
   declaration: "separate",
   scriptModule: false,
   package: {

--- a/packages/cesr/src/version.ts
+++ b/packages/cesr/src/version.ts
@@ -3,7 +3,7 @@
  * Do not edit by hand.
  */
 /** Package semantic version copied from the owning package manifest. */
-export const PACKAGE_VERSION = "0.5.0";
+export const PACKAGE_VERSION = "0.6.0";
 /** Optional build metadata stamp injected by release/CI workflows. */
 export const BUILD_METADATA = "";
 /** User-facing version string with build metadata appended when present. */

--- a/packages/keri/scripts/build_npm.ts
+++ b/packages/keri/scripts/build_npm.ts
@@ -6,13 +6,13 @@ const RUNTIME_ENTRYPOINT = "./src/npm/runtime.ts";
 const DB_ENTRYPOINT = "./src/npm/db.ts";
 const OUT_DIR = "./npm";
 const DNT_IMPORT_MAP_PATH = "./.dnt.import-map.json";
-const NPM_MAIN_PATH = "./esm/keri/src/npm/index.js";
+const NPM_MAIN_PATH = "./esm/keri/npm/src/keri/src/npm/index.js";
 const NPM_TYPES_PATH = "./types/keri/src/npm/index.d.ts";
-const NPM_CLI_PATH = "./esm/keri/src/npm/cli.js";
+const NPM_CLI_PATH = "./esm/keri/npm/src/keri/src/npm/cli.js";
 const NPM_CLI_TYPES_PATH = "./types/keri/src/npm/cli.d.ts";
-const NPM_RUNTIME_PATH = "./esm/keri/src/npm/runtime.js";
+const NPM_RUNTIME_PATH = "./esm/keri/npm/src/keri/src/npm/runtime.js";
 const NPM_RUNTIME_TYPES_PATH = "./types/keri/src/npm/runtime.d.ts";
-const NPM_DB_PATH = "./esm/keri/src/npm/db.js";
+const NPM_DB_PATH = "./esm/keri/npm/src/keri/src/npm/db.js";
 const NPM_DB_TYPES_PATH = "./types/keri/src/npm/db.d.ts";
 
 interface PackageManifest {
@@ -138,6 +138,7 @@ try {
     importMap: DNT_IMPORT_MAP_PATH,
     typeCheck: false,
     test: false,
+    skipNpmInstall: true,
     declaration: "separate",
     scriptModule: false,
     package: {

--- a/packages/keri/scripts/check_library_boundary.ts
+++ b/packages/keri/scripts/check_library_boundary.ts
@@ -22,19 +22,19 @@ const NPM_MANIFEST_PATH = new URL("../npm/package.json", import.meta.url);
 
 const EXPECTED_EXPORTS: Record<string, ExportTarget> = {
   ".": {
-    import: "./esm/keri/src/npm/index.js",
+    import: "./esm/keri/npm/src/keri/src/npm/index.js",
     types: "./types/keri/src/npm/index.d.ts",
   },
   "./cli": {
-    import: "./esm/keri/src/npm/cli.js",
+    import: "./esm/keri/npm/src/keri/src/npm/cli.js",
     types: "./types/keri/src/npm/cli.d.ts",
   },
   "./runtime": {
-    import: "./esm/keri/src/npm/runtime.js",
+    import: "./esm/keri/npm/src/keri/src/npm/runtime.js",
     types: "./types/keri/src/npm/runtime.d.ts",
   },
   "./db": {
-    import: "./esm/keri/src/npm/db.js",
+    import: "./esm/keri/npm/src/keri/src/npm/db.js",
     types: "./types/keri/src/npm/db.d.ts",
   },
 };

--- a/packages/tufa/scripts/build_npm.ts
+++ b/packages/tufa/scripts/build_npm.ts
@@ -96,6 +96,7 @@ try {
     importMap: DNT_IMPORT_MAP_PATH,
     typeCheck: false,
     test: false,
+    skipNpmInstall: true,
     declaration: "separate",
     scriptModule: false,
     package: {


### PR DESCRIPTION
## Summary

- Bumps `cesr-ts` from `0.5.0` to `0.6.0` with changelog and generated runtime version updates.
- Skips DNT's internal registry `npm install` during npm artifact generation so staged workspace releases can build before dependent packages are published.
- Corrects the generated `keri-ts` npm manifest export paths to match the actual DNT ESM output and keeps the boundary check aligned with those paths.

## Why

`keri-ts` derives its npm `cesr-ts` dependency range from the workspace CESR package version. During the attempted joint release build, DNT's internal npm install tried to resolve unpublished `cesr-ts@0.6.0` from the public registry. The repo already validates installability with local tarball smoke tests, so artifact generation should not depend on registry availability for unpublished staged versions.

The smoke test also exposed that `keri-ts` package exports pointed to paths not present in the tarball. The manifest now points at the generated DNT layout actually packaged in `npm pack`.

## Local Validation

- `deno task npm:build:all`
- `deno task fmt:check`
- `deno task lint`
- `deno task check`
- `deno task version:check`
- `deno task test:cesr`
- `bash scripts/smoke-test-keri-npm.sh /Users/kbull/tmp/keri-release-smoke/keri-ts-0.5.0.tgz /Users/kbull/tmp/keri-release-smoke/cesr-ts-0.6.0.tgz`
- `bash scripts/smoke-test-tufa-npm.sh /Users/kbull/tmp/keri-release-smoke/keri-ts-tufa-0.5.0.tgz /Users/kbull/tmp/keri-release-smoke/cesr-ts-0.6.0.tgz /Users/kbull/tmp/keri-release-smoke/keri-ts-0.5.0.tgz`