### PR TITLE
[codex] Release keri-ts and tufa 0.6.0

### DIFF
--- a/packages/keri/CHANGELOG.md
+++ b/packages/keri/CHANGELOG.md
@@ -1,5 +1,11 @@
 # keri-ts
 
+## 0.6.0
+
+### Minor Changes
+
+- Complete delegation communication support for interop release readiness, including notification-backed delegation flows, mailbox/reply processing fixes, and npm artifact build validation needed for staged publication.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/keri/deno.json
+++ b/packages/keri/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "keri-ts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "exports": {
     ".": "./mod.ts",
     "./cli": "./cli.ts",

--- a/packages/keri/package.json
+++ b/packages/keri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keri-ts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "KERI TypeScript protocol and runtime library",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/keri/src/app/version.ts
+++ b/packages/keri/src/app/version.ts
@@ -3,7 +3,7 @@
  * Do not edit by hand.
  */
 /** Package semantic version copied from the owning package manifest. */
-export const PACKAGE_VERSION = "0.5.0";
+export const PACKAGE_VERSION = "0.6.0";
 /** Optional build metadata stamp injected by release/CI workflows. */
 export const BUILD_METADATA = "";
 /** User-facing version string with build metadata appended when present. */

--- a/packages/tufa/CHANGELOG.md
+++ b/packages/tufa/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @keri-ts/tufa
+
+## 0.6.0
+
+### Minor Changes
+
+- Complete delegation communication support for interop release readiness, including notification-backed delegation flows, mailbox/reply processing fixes, and npm artifact build validation needed for staged publication.

--- a/packages/tufa/deno.json
+++ b/packages/tufa/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "tufa",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/tufa/package.json
+++ b/packages/tufa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keri-ts/tufa",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Trust Utilities for Agents CLI application package",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/tufa/src/version.ts
+++ b/packages/tufa/src/version.ts
@@ -3,7 +3,7 @@
  * Do not edit by hand.
  */
 /** Package semantic version copied from the owning package manifest. */
-export const PACKAGE_VERSION = "0.5.0";
+export const PACKAGE_VERSION = "0.6.0";
 /** Optional build metadata stamp injected by release/CI workflows. */
 export const BUILD_METADATA = "";
 /** User-facing version string with build metadata appended when present. */


### PR DESCRIPTION
## Summary

- Bumps `keri-ts` from `0.5.0` to `0.6.0`.
- Bumps `@keri-ts/tufa` from `0.5.0` to `0.6.0`.
- Adds the generated Tufa changelog entry and updates generated runtime version constants.

## Why

This completes the staged release after `cesr-ts@0.6.0` was published first. `keri-ts` depends on `cesr-ts`, and `@keri-ts/tufa` depends on both, so this PR keeps the release ordering compatible with the documented tag-based publication workflows.

## Local validation

- `deno task version:check`
- `deno task npm:build:all`
- `deno task fmt:check`
- `deno task lint`
- `deno task check`
- `deno task test:cesr`
- Packed npm tarball smoke test for `keri-ts@0.6.0` with local `cesr-ts@0.6.0`
- Packed npm tarball smoke test for `@keri-ts/tufa@0.6.0` with local `keri-ts@0.6.0` and `cesr-ts@0.6.0`

## Local LMDB note

LMDB-backed local tests are currently blocked on this macOS host by the native `npm:lmdb@3.5.3` binding failing a direct minimal `open()` with `No space left on device`, even with a 1 MiB map and outside the test harness. CI should be treated as the authoritative full LMDB-backed gate for this PR.