### PR TITLE
[codex] Harden keri npm release artifact exports

### DIFF
--- a/packages/keri/scripts/build_npm.ts
+++ b/packages/keri/scripts/build_npm.ts
@@ -20,8 +20,30 @@ interface PackageManifest {
 }
 
 interface BuiltNpmPackageManifest {
+  main?: string;
+  module?: string;
+  types?: string;
   exports?: Record<string, unknown>;
 }
+
+interface NpmExportTarget {
+  import: string;
+  types: string;
+}
+
+interface NpmExportTargets {
+  root: NpmExportTarget;
+  cli: NpmExportTarget;
+  runtime: NpmExportTarget;
+  db: NpmExportTarget;
+}
+
+const ENTRYPOINT_MARKERS = {
+  root: "npm package root entrypoint.",
+  cli: "npm subpath entrypoint for `keri-ts/cli`.",
+  runtime: "npm subpath entrypoint for `keri-ts/runtime`.",
+  db: "npm subpath entrypoint for `keri-ts/db`.",
+} as const;
 
 /**
  * Resolve the version of the package from package.json or the environment variable.
@@ -90,26 +112,139 @@ function writeDntImportMap(cesrVersion: string): void {
   );
 }
 
+function listFilesSync(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of Deno.readDirSync(dir)) {
+    const path = `${dir}/${entry.name}`;
+    if (entry.isDirectory) {
+      files.push(...listFilesSync(path));
+    } else if (entry.isFile) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function toPackagePath(path: string): string {
+  return `./${path.replace(`${OUT_DIR}/`, "")}`;
+}
+
+function findGeneratedEntrypoint(
+  root: string,
+  fileName: string,
+  marker: string,
+): string {
+  const matches = listFilesSync(root).filter((path) => {
+    if (!path.endsWith(`/${fileName}`)) {
+      return false;
+    }
+    return Deno.readTextFileSync(path).includes(marker);
+  });
+
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one generated ${fileName} containing ${
+        JSON.stringify(marker)
+      } under ${root}, found ${matches.length}: ${matches.join(", ")}`,
+    );
+  }
+
+  return toPackagePath(matches[0]);
+}
+
+function assertPackagePathExists(path: string): void {
+  const relative = path.replace(/^\.\//, "");
+  const fullPath = `${OUT_DIR}/${relative}`;
+  const stat = Deno.statSync(fullPath);
+  if (!stat.isFile) {
+    throw new Error(`Expected npm package path to be a file: ${path}`);
+  }
+}
+
+function resolveGeneratedExportTargets(): NpmExportTargets {
+  const targets = {
+    root: {
+      import: findGeneratedEntrypoint(
+        `${OUT_DIR}/esm`,
+        "index.js",
+        ENTRYPOINT_MARKERS.root,
+      ),
+      types: findGeneratedEntrypoint(
+        `${OUT_DIR}/types`,
+        "index.d.ts",
+        ENTRYPOINT_MARKERS.root,
+      ),
+    },
+    cli: {
+      import: findGeneratedEntrypoint(
+        `${OUT_DIR}/esm`,
+        "cli.js",
+        ENTRYPOINT_MARKERS.cli,
+      ),
+      types: findGeneratedEntrypoint(
+        `${OUT_DIR}/types`,
+        "cli.d.ts",
+        ENTRYPOINT_MARKERS.cli,
+      ),
+    },
+    runtime: {
+      import: findGeneratedEntrypoint(
+        `${OUT_DIR}/esm`,
+        "runtime.js",
+        ENTRYPOINT_MARKERS.runtime,
+      ),
+      types: findGeneratedEntrypoint(
+        `${OUT_DIR}/types`,
+        "runtime.d.ts",
+        ENTRYPOINT_MARKERS.runtime,
+      ),
+    },
+    db: {
+      import: findGeneratedEntrypoint(
+        `${OUT_DIR}/esm`,
+        "db.js",
+        ENTRYPOINT_MARKERS.db,
+      ),
+      types: findGeneratedEntrypoint(
+        `${OUT_DIR}/types`,
+        "db.d.ts",
+        ENTRYPOINT_MARKERS.db,
+      ),
+    },
+  };
+
+  for (const target of Object.values(targets)) {
+    assertPackagePathExists(target.import);
+    assertPackagePathExists(target.types);
+  }
+
+  return targets;
+}
+
 function normalizeBuiltManifest(): void {
   const packageJsonPath = `${OUT_DIR}/package.json`;
   const raw = Deno.readTextFileSync(packageJsonPath);
   const manifest = JSON.parse(raw) as BuiltNpmPackageManifest;
+  const targets = resolveGeneratedExportTargets();
+  manifest.main = targets.root.import;
+  manifest.module = targets.root.import;
+  manifest.types = targets.root.types;
   manifest.exports = {
     ".": {
-      import: NPM_MAIN_PATH,
-      types: NPM_TYPES_PATH,
+      import: targets.root.import,
+      types: targets.root.types,
     },
     "./cli": {
-      import: NPM_CLI_PATH,
-      types: NPM_CLI_TYPES_PATH,
+      import: targets.cli.import,
+      types: targets.cli.types,
     },
     "./runtime": {
-      import: NPM_RUNTIME_PATH,
-      types: NPM_RUNTIME_TYPES_PATH,
+      import: targets.runtime.import,
+      types: targets.runtime.types,
     },
     "./db": {
-      import: NPM_DB_PATH,
-      types: NPM_DB_TYPES_PATH,
+      import: targets.db.import,
+      types: targets.db.types,
     },
   };
   Deno.writeTextFileSync(
@@ -130,7 +265,12 @@ writeDntImportMap(cesrPackageVersion);
 // build keri-ts package
 try {
   await build({
-    entryPoints: [ENTRYPOINT, CLI_ENTRYPOINT, RUNTIME_ENTRYPOINT, DB_ENTRYPOINT],
+    entryPoints: [
+      ENTRYPOINT,
+      CLI_ENTRYPOINT,
+      RUNTIME_ENTRYPOINT,
+      DB_ENTRYPOINT,
+    ],
     outDir: OUT_DIR,
     shims: {
       deno: true,

--- a/scripts/smoke-test-keri-npm.sh
+++ b/scripts/smoke-test-keri-npm.sh
@@ -27,6 +27,64 @@ if [[ ! -f "${TARBALL_PATH}" ]]; then
   exit 1
 fi
 
+assert_tarball_export_targets() {
+  local manifest_json
+  local target_paths
+  manifest_json="$(tar -xOzf "${TARBALL_PATH}" package/package.json)"
+  target_paths="$(MANIFEST_JSON="${manifest_json}" node --input-type=module - <<'EOF'
+const manifest = JSON.parse(process.env.MANIFEST_JSON ?? "{}");
+const targets = [];
+
+function collectTarget(target) {
+  if (typeof target === "string") {
+    targets.push(target);
+    return;
+  }
+  if (!target || typeof target !== "object") {
+    return;
+  }
+  for (const value of Object.values(target)) {
+    collectTarget(value);
+  }
+}
+
+collectTarget(manifest.main);
+collectTarget(manifest.module);
+collectTarget(manifest.types);
+for (const target of Object.values(manifest.exports ?? {})) {
+  collectTarget(target);
+}
+
+for (const target of [...new Set(targets)]) {
+  if (!target.startsWith("./")) {
+    continue;
+  }
+  console.log(`package/${target.slice(2)}`);
+}
+EOF
+)"
+
+  if [[ -z "${target_paths}" ]]; then
+    echo "No package export targets found in ${TARBALL_PATH}" >&2
+    exit 1
+  fi
+
+  local listing
+  listing="$(tar -tzf "${TARBALL_PATH}")"
+  while IFS= read -r target_path; do
+    if ! grep -qxF "${target_path}" <<<"${listing}"; then
+      echo "Packed tarball is missing package export target: ${target_path}" >&2
+      echo "Export targets:" >&2
+      echo "${target_paths}" >&2
+      echo "Matching package contents:" >&2
+      grep -E '^package/(package\.json|esm/|types/)' <<<"${listing}" | head -200 >&2
+      exit 1
+    fi
+  done <<<"${target_paths}"
+}
+
+assert_tarball_export_targets
+
 TARBALL_DIR="$(cd "$(dirname "${TARBALL_PATH}")" && pwd)"
 TARBALL_NAME="$(basename "${TARBALL_PATH}")"
 INSTALL_TARGETS=("/pkg/${TARBALL_NAME}")
@@ -57,6 +115,8 @@ npm init -y >/dev/null 2>&1
 npm install ${INSTALL_TARGETS[*]} >/dev/null
 echo \"Node runtime: \$(node --version), npm: \$(npm --version)\" >&2
 node --input-type=module - <<'EOF'
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import * as keri from 'keri-ts';
 import * as runtime from 'keri-ts/runtime';
 import * as db from 'keri-ts/db';
@@ -65,6 +125,41 @@ function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
+}
+
+const packageRoot = 'node_modules/keri-ts';
+const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+const targetPaths = new Set();
+
+function collectTarget(target) {
+  if (typeof target === 'string') {
+    targetPaths.add(target);
+    return;
+  }
+  if (!target || typeof target !== 'object') {
+    return;
+  }
+  for (const value of Object.values(target)) {
+    collectTarget(value);
+  }
+}
+
+collectTarget(manifest.main);
+collectTarget(manifest.module);
+collectTarget(manifest.types);
+for (const target of Object.values(manifest.exports ?? {})) {
+  collectTarget(target);
+}
+
+for (const target of targetPaths) {
+  if (!target.startsWith('./')) {
+    continue;
+  }
+  const installedPath = join(packageRoot, target.slice(2));
+  assert(
+    existsSync(installedPath),
+    'installed keri-ts package is missing export target ' + target,
+  );
 }
 
 assert(typeof keri.PACKAGE_VERSION === 'string' && keri.PACKAGE_VERSION.length > 0, 'keri-ts root missing PACKAGE_VERSION');


### PR DESCRIPTION
## Summary
- Discover `keri-ts` npm export targets from DNT output before normalizing the package manifest.
- Assert generated export targets exist during package build.
- Assert packed and installed export targets in the `keri-ts` npm smoke test before ESM imports.

## Context
The `keri-v0.6.0` release workflow failed twice at the packed-artifact Docker smoke step with `ERR_MODULE_NOT_FOUND` for the root `keri-ts` export target. Publish was skipped; `keri-ts@0.6.0` is not currently visible on npm.

## Verification
- `bash -n scripts/smoke-test-keri-npm.sh`
- `deno check packages/keri/scripts/build_npm.ts`
- `deno task fmt:check`
- `deno task version:check`
- `deno task check`
- `deno task build:npm && deno task smoke:keri:npm`
- `SMOKE_NODE_IMAGE=node:26-alpine bash scripts/smoke-test-keri-npm.sh packages/keri/npm/keri-ts-0.6.0.tgz`
