### PR TITLE
[codex] Harden tufa npm bin export paths

### DIFF
--- a/packages/tufa/scripts/build_npm.ts
+++ b/packages/tufa/scripts/build_npm.ts
@@ -14,8 +14,23 @@ interface PackageManifest {
 
 interface BuiltNpmPackageManifest {
   name?: string;
+  main?: string;
+  module?: string;
+  types?: string;
+  bin?: Record<string, string>;
   exports?: Record<string, unknown>;
 }
+
+interface TufaNpmTargets {
+  root: {
+    import: string;
+    types: string;
+  };
+  bin: string;
+}
+
+const ROOT_ENTRYPOINT_MARKER = "Minimal npm module surface for the `tufa` application package.";
+const BIN_ENTRYPOINT_MARKER = "run(() => tufa(argv.slice(2)))";
 
 function resolvePackageVersion(): string {
   const raw = Deno.readTextFileSync("./package.json");
@@ -56,21 +71,106 @@ function writeDntImportMap(
   );
 }
 
-function normalizeBuiltManifest(): void {
+function listFilesSync(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of Deno.readDirSync(dir)) {
+    const path = `${dir}/${entry.name}`;
+    if (entry.isDirectory) {
+      files.push(...listFilesSync(path));
+    } else if (entry.isFile) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function toPackagePath(path: string): string {
+  return `./${path.replace(`${OUT_DIR}/`, "")}`;
+}
+
+function findGeneratedEntrypoint(
+  root: string,
+  fileName: string,
+  marker: string,
+): string {
+  const matches = listFilesSync(root).filter((path) => {
+    if (!path.endsWith(`/${fileName}`)) {
+      return false;
+    }
+    return Deno.readTextFileSync(path).includes(marker);
+  });
+
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one generated ${fileName} containing ${
+        JSON.stringify(marker)
+      } under ${root}, found ${matches.length}: ${matches.join(", ")}`,
+    );
+  }
+
+  return toPackagePath(matches[0]);
+}
+
+function assertPackagePathExists(path: string): void {
+  const relative = path.replace(/^\.\//, "");
+  const fullPath = `${OUT_DIR}/${relative}`;
+  const stat = Deno.statSync(fullPath);
+  if (!stat.isFile) {
+    throw new Error(`Expected npm package path to be a file: ${path}`);
+  }
+}
+
+function resolveGeneratedTargets(): TufaNpmTargets {
+  const targets = {
+    root: {
+      import: findGeneratedEntrypoint(
+        `${OUT_DIR}/esm`,
+        "index.js",
+        ROOT_ENTRYPOINT_MARKER,
+      ),
+      types: findGeneratedEntrypoint(
+        `${OUT_DIR}/types`,
+        "index.d.ts",
+        ROOT_ENTRYPOINT_MARKER,
+      ),
+    },
+    bin: findGeneratedEntrypoint(
+      `${OUT_DIR}/esm`,
+      "cli-node.js",
+      BIN_ENTRYPOINT_MARKER,
+    ),
+  };
+
+  assertPackagePathExists(targets.root.import);
+  assertPackagePathExists(targets.root.types);
+  assertPackagePathExists(targets.bin);
+
+  return targets;
+}
+
+function normalizeBuiltManifest(): TufaNpmTargets {
   const packageJsonPath = `${OUT_DIR}/package.json`;
   const raw = Deno.readTextFileSync(packageJsonPath);
   const manifest = JSON.parse(raw) as BuiltNpmPackageManifest;
+  const targets = resolveGeneratedTargets();
   manifest.name = "@keri-ts/tufa";
+  manifest.main = targets.root.import;
+  manifest.module = targets.root.import;
+  manifest.types = targets.root.types;
   manifest.exports = {
     ".": {
-      import: NPM_MAIN_PATH,
-      types: NPM_TYPES_PATH,
+      import: targets.root.import,
+      types: targets.root.types,
     },
+  };
+  manifest.bin = {
+    tufa: targets.bin,
   };
   Deno.writeTextFileSync(
     packageJsonPath,
     `${JSON.stringify(manifest, null, 2)}\n`,
   );
+  return targets;
 }
 
 if (!Deno.env.has("NPM_CONFIG_IGNORE_SCRIPTS")) {
@@ -147,7 +247,7 @@ try {
       },
     },
     postBuild() {
-      normalizeBuiltManifest();
+      const targets = normalizeBuiltManifest();
       try {
         Deno.removeSync(`${OUT_DIR}/esm/keri`, { recursive: true });
       } catch {
@@ -161,7 +261,7 @@ try {
       Deno.copyFileSync("./README.md", `${OUT_DIR}/README.md`);
       Deno.copyFileSync("../../LICENSE", `${OUT_DIR}/LICENSE`);
 
-      const binPath = `${OUT_DIR}/${NPM_BIN_PATH.replace(/^\.\//, "")}`;
+      const binPath = `${OUT_DIR}/${targets.bin.replace(/^\.\//, "")}`;
       const current = Deno.readTextFileSync(binPath);
       if (!current.startsWith("#!/usr/bin/env node\n")) {
         Deno.writeTextFileSync(binPath, `#!/usr/bin/env node\n${current}`);

--- a/scripts/smoke-test-tufa-npm.sh
+++ b/scripts/smoke-test-tufa-npm.sh
@@ -35,6 +35,65 @@ if [[ ! -f "${SAMPLES_DIR}/${SAMPLE_STREAM_REL}" ]]; then
   exit 1
 fi
 
+assert_tarball_package_targets() {
+  local manifest_json
+  local target_paths
+  manifest_json="$(tar -xOzf "${TARBALL_PATH}" package/package.json)"
+  target_paths="$(MANIFEST_JSON="${manifest_json}" node --input-type=module - <<'EOF'
+const manifest = JSON.parse(process.env.MANIFEST_JSON ?? "{}");
+const targets = [];
+
+function collectTarget(target) {
+  if (typeof target === "string") {
+    targets.push(target);
+    return;
+  }
+  if (!target || typeof target !== "object") {
+    return;
+  }
+  for (const value of Object.values(target)) {
+    collectTarget(value);
+  }
+}
+
+collectTarget(manifest.main);
+collectTarget(manifest.module);
+collectTarget(manifest.types);
+collectTarget(manifest.bin);
+for (const target of Object.values(manifest.exports ?? {})) {
+  collectTarget(target);
+}
+
+for (const target of [...new Set(targets)]) {
+  if (!target.startsWith("./")) {
+    continue;
+  }
+  console.log(`package/${target.slice(2)}`);
+}
+EOF
+)"
+
+  if [[ -z "${target_paths}" ]]; then
+    echo "No package export/bin targets found in ${TARBALL_PATH}" >&2
+    exit 1
+  fi
+
+  local listing
+  listing="$(tar -tzf "${TARBALL_PATH}")"
+  while IFS= read -r target_path; do
+    if ! grep -qxF "${target_path}" <<<"${listing}"; then
+      echo "Packed tarball is missing package target: ${target_path}" >&2
+      echo "Package targets:" >&2
+      echo "${target_paths}" >&2
+      echo "Matching package contents:" >&2
+      grep -E '^package/(package\.json|esm/|types/)' <<<"${listing}" | head -200 >&2
+      exit 1
+    fi
+  done <<<"${target_paths}"
+}
+
+assert_tarball_package_targets
+
 TARBALL_DIR="$(cd "$(dirname "${TARBALL_PATH}")" && pwd)"
 TARBALL_NAME="$(basename "${TARBALL_PATH}")"
 INSTALL_TARGETS=("/pkg/${TARBALL_NAME}")


### PR DESCRIPTION
## Summary
- Discover the generated `@keri-ts/tufa` npm module export and CLI bin entrypoint from DNT output before normalizing `package.json`.
- Assert the generated module, type, and bin targets exist during package build.
- Assert packed Tufa npm tarballs contain all manifest export/bin targets before Docker smoke.

## Context
The `tufa-v0.6.0` release workflow failed in `build npm packages` before publish because the hardcoded `./npm/esm/tufa/npm/src/app/cli-node.js` bin path was absent in CI's DNT output. `@keri-ts/tufa@0.6.0` has not been published.

## Verification
- `bash -n scripts/smoke-test-tufa-npm.sh`
- `deno check packages/tufa/scripts/build_npm.ts`
- `deno task fmt:check`
- `deno task check`
- `deno task tufa:build:npm && deno task smoke:tufa:npm`
- `SMOKE_NODE_IMAGE=node:26-alpine bash scripts/smoke-test-tufa-npm.sh packages/tufa/npm/keri-ts-tufa-0.6.0.tgz`
