### PR TITLE
[codex] Normalize tufa npm bin metadata

### DIFF
--- a/packages/tufa/scripts/build_npm.ts
+++ b/packages/tufa/scripts/build_npm.ts
@@ -164,7 +164,7 @@ function normalizeBuiltManifest(): TufaNpmTargets {
     },
   };
   manifest.bin = {
-    tufa: targets.bin,
+    tufa: targets.bin.replace(/^\.\//, ""),
   };
   Deno.writeTextFileSync(
     packageJsonPath,

--- a/scripts/smoke-test-tufa-npm.sh
+++ b/scripts/smoke-test-tufa-npm.sh
@@ -65,10 +65,13 @@ for (const target of Object.values(manifest.exports ?? {})) {
 }
 
 for (const target of [...new Set(targets)]) {
-  if (!target.startsWith("./")) {
+  if (target.startsWith("./")) {
+    console.log(`package/${target.slice(2)}`);
     continue;
   }
-  console.log(`package/${target.slice(2)}`);
+  if (!target.startsWith("/") && !target.startsWith("../") && !target.includes("://")) {
+    console.log(`package/${target}`);
+  }
 }
 EOF
 )"


### PR DESCRIPTION
## Summary
- Write Tufa npm `bin.tufa` as npm's expected bare relative path instead of `./...`.
- Keep using the discovered generated bin path for filesystem shebang/chmod work.
- Let the Tufa tarball smoke assertion validate both `./path` and bare relative manifest targets.

## Context
The corrected `tufa-v0.6.0` release passed build, dependency verification, smoke, and artifact upload, then failed at npm publish with a registry `404 PUT` for the `@keri-ts/tufa` scope/package. While inspecting that failure, npm also reported publish-time bin metadata auto-correction. This PR removes that package metadata warning so the remaining Tufa blocker is the external npm scope/auth issue.

## Verification
- `bash -n scripts/smoke-test-tufa-npm.sh`
- `deno task fmt:check`
- `deno check packages/tufa/scripts/build_npm.ts`
- `deno task tufa:build:npm && deno task smoke:tufa:npm`
- `npm publish --dry-run --access public` from an unpacked Tufa tarball; verified no `auto-corrected` or `bin[tufa]` warning
- `deno task check`
