### PR TITLE
[codex] Record release packaging learnings

### DIFF
--- a/.agents/PROJECT_LEARNINGS.md
+++ b/.agents/PROJECT_LEARNINGS.md
@@ -108,12 +108,15 @@ stay short enough to reread at session start.
    rather than reintroducing duplicate wrapper families.
 6. Treat source-vs-npm drift in `tufa` as a release blocker; smoke the packed
    artifact when CLI or Node-host behavior changes.
-7. Keep bootstrap config on honest CLI/file seams rather than hidden default
+7. Treat scoped npm package publication as its own release seam:
+   `@keri-ts/tufa` needs `@keri-ts` scope ownership/token permission before tag
+   publish can succeed, even when artifact build/smoke/dry-run all pass.
+8. Keep bootstrap config on honest CLI/file seams rather than hidden default
    paths or ad hoc store mutation in scripts.
-8. Keep host-prefix selection explicit and conservative; do not leak
+9. Keep host-prefix selection explicit and conservative; do not leak
    system-managed identities into normal user-facing host startup.
-9. Keep witness interop claims tied to the scenarios actually proved.
-10. Keep test-lane ownership explicit as mailbox/runtime work grows.
+10. Keep witness interop claims tied to the scenarios actually proved.
+11. Keep test-lane ownership explicit as mailbox/runtime work grows.
 
 ## Recent Durable Changes
 

--- a/.agents/learnings/PROJECT_LEARNINGS_WITNESS_WATCHER_OBSERVER_INFRA.md
+++ b/.agents/learnings/PROJECT_LEARNINGS_WITNESS_WATCHER_OBSERVER_INFRA.md
@@ -55,6 +55,13 @@ release, and interoperability operations.
     rather than rebuilding dependencies on removed `packages/keri` host paths.
 18. `tufa db dump` is the preferred operational seam for localizing
     controller-vs-witness or provider-vs-controller state drift.
+19. Npm release build scripts should derive manifest export/bin paths from the
+    generated DNT output and assert those targets in the packed tarball; hard
+    coded emitted paths are release blockers.
+20. Scoped package publication is a separate registry-auth seam from artifact
+    correctness. `@keri-ts/tufa` can build, smoke, dry-run, and sign provenance
+    successfully while still failing publish until the npm token has permission
+    for the `@keri-ts` scope.
 
 ## Use This Doc For
 
@@ -87,6 +94,9 @@ release, and interoperability operations.
    broadening a different test.
 8. Keep new host/integration tests pointed at `packages/tufa` surfaces so
    package-boundary drift is caught where users actually run the code.
+9. Before retrying `@keri-ts/tufa` publication, fix npm registry ownership or
+   token permissions for the `@keri-ts` scope; repository-side release checks
+   are already capable of proving the package artifact.
 
 ## Milestone Rollup
 
@@ -114,3 +124,13 @@ release, and interoperability operations.
 - Worker defaults were capped and tied to honest isolation boundaries.
 - Oversized parallel lanes were split, and mixed runtime files were physically
   separated so the test topology matches the real safe concurrency boundary.
+
+### 2026-06-06 - Release Artifact Validation Became Target-Aware
+
+- `cesr-ts@0.6.0` and `keri-ts@0.6.0` published through CI after PR-gated
+  version and packaging fixes.
+- `keri-ts` and `@keri-ts/tufa` npm build scripts now treat DNT output paths as
+  generated facts, then normalize and assert manifest targets before smoke.
+- `@keri-ts/tufa@0.6.0` remains blocked at npm publish by `@keri-ts` scope
+  authorization despite passing quality, build, npm dry-run, Docker smoke, and
+  artifact upload in CI.


### PR DESCRIPTION
## Summary
- record DNT-output-derived npm manifest path invariant
- record @keri-ts/tufa npm scope authorization blocker
- add top-level release follow-up for scoped npm publication

## Verification
- deno task fmt:check
- make memory-reindex (bullctx)
- make memory-check (bullctx)