### PR TITLE
[codex] Document recent delegation and release code

### DIFF
--- a/packages/cesr/src/core/parser-frame-parser.ts
+++ b/packages/cesr/src/core/parser-frame-parser.ts
@@ -437,6 +437,9 @@ export class FrameParser {
         streamVersion,
       };
     } catch (_error) {
+      // Non-native body groups wrap one Matter primitive. If Serder hydration
+      // fails, expose the primitive body bytes only; callers that inspect the
+      // fallback should not see the surrounding group counter envelope.
       const raw = matter.raw;
       return {
         frame: {

--- a/packages/cesr/src/primitives/matter.ts
+++ b/packages/cesr/src/primitives/matter.ts
@@ -85,6 +85,13 @@ function matterNameForCode(code: string): string {
   return name;
 }
 
+/**
+ * Select the concrete variable-length Matter code for the raw payload size.
+ *
+ * Variable families encode lead bytes and soft-size width in the selector
+ * itself. Normalizing once during construction keeps generated qb64/qb2 forms
+ * deterministic without leaking that sizing policy to primitive callers.
+ */
 function normalizeVariableMatterCode(code: string, raw: Uint8Array): string {
   const sizage = MATTER_SIZES.get(code);
   if (!sizage || sizage.fs !== null) {

--- a/packages/keri/scripts/build_npm.ts
+++ b/packages/keri/scripts/build_npm.ts
@@ -1,3 +1,10 @@
+/**
+ * Build the `keri-ts` npm package with DNT and normalize generated metadata.
+ *
+ * DNT may change generated path depth as imports evolve, so this script treats
+ * marker comments in the generated entrypoints as the source of truth for npm
+ * manifest targets instead of hard-coding the final tree layout.
+ */
 import { build, emptyDir } from "@deno/dnt";
 
 const ENTRYPOINT = "./src/npm/index.ts";
@@ -112,6 +119,7 @@ function writeDntImportMap(cesrVersion: string): void {
   );
 }
 
+/** Recursively list generated files so marker lookup works across DNT layouts. */
 function listFilesSync(dir: string): string[] {
   const files: string[] = [];
   for (const entry of Deno.readDirSync(dir)) {
@@ -125,10 +133,17 @@ function listFilesSync(dir: string): string[] {
   return files;
 }
 
+/** Convert an on-disk generated path into a package.json-relative target. */
 function toPackagePath(path: string): string {
   return `./${path.replace(`${OUT_DIR}/`, "")}`;
 }
 
+/**
+ * Locate exactly one generated entrypoint by file name and marker comment.
+ *
+ * This is the release invariant that catches DNT path drift: npm metadata is
+ * rewritten only when the intended generated module/declaration pair exists.
+ */
 function findGeneratedEntrypoint(
   root: string,
   fileName: string,
@@ -152,6 +167,7 @@ function findGeneratedEntrypoint(
   return toPackagePath(matches[0]);
 }
 
+/** Assert that a manifest target points at a real file inside the built package. */
 function assertPackagePathExists(path: string): void {
   const relative = path.replace(/^\.\//, "");
   const fullPath = `${OUT_DIR}/${relative}`;
@@ -161,6 +177,7 @@ function assertPackagePathExists(path: string): void {
   }
 }
 
+/** Resolve all npm root and subpath export targets from generated output. */
 function resolveGeneratedExportTargets(): NpmExportTargets {
   const targets = {
     root: {
@@ -221,6 +238,12 @@ function resolveGeneratedExportTargets(): NpmExportTargets {
   return targets;
 }
 
+/**
+ * Rewrite DNT's manifest paths to the discovered generated target paths.
+ *
+ * The placeholder constants above keep the DNT build happy; this post-build
+ * step makes the packed artifact truthful for Node and TypeScript consumers.
+ */
 function normalizeBuiltManifest(): void {
   const packageJsonPath = `${OUT_DIR}/package.json`;
   const raw = Deno.readTextFileSync(packageJsonPath);

--- a/packages/keri/src/app/cli/delegate.ts
+++ b/packages/keri/src/app/cli/delegate.ts
@@ -1,3 +1,16 @@
+/**
+ * Delegator-side CLI approval for pending delegated events.
+ *
+ * KERIpy correspondence:
+ * - this is the bounded command analogue of KLI's delegation approval flow
+ * - pending work is discovered from durable `delegables.` escrow, not from
+ *   controller notifications
+ *
+ * Maintainer rule:
+ * - `/delegate/request` notifications are UI hints only
+ * - approval ordering and event selection come from the delegated-event escrows
+ *   and the delegator's own KEL state
+ */
 import { type Operation, spawn } from "npm:effection@^3.6.0";
 import { Diger, type SerderKERI } from "../../../../cesr/mod.ts";
 import type { CueEmission } from "../../core/cues.ts";
@@ -30,6 +43,7 @@ interface DelegateConfirmArgs {
   codeTime?: string;
 }
 
+/** Build witness auth payloads from CLI `<witness>:<code>` inputs. */
 function resolveWitnessAuths(
   witnesses: readonly string[],
   codes: readonly string[],
@@ -64,6 +78,7 @@ function resolveWitnessAuths(
   return auths;
 }
 
+/** Return pending delegated events for one local delegator, oldest first. */
 function pendingDelegations(
   hby: Habery,
   delegatorPre: string,
@@ -87,6 +102,7 @@ function pendingDelegations(
   return pending.sort((left, right) => (left.sn ?? 0) - (right.sn ?? 0));
 }
 
+/** Determine the delegator prefix for `dip` or `drt` escrow material. */
 function delegationSourcePrefix(
   hby: Habery,
   serder: SerderKERI,
@@ -103,6 +119,7 @@ function delegationSourcePrefix(
     ?? hby.db.getState(delegatedPre)?.di;
 }
 
+/** Project a delegated event into the seal embedded by the approving event. */
 function anchorData(serder: SerderKERI): { i: string; s: string; d: string } {
   if (!serder.pre || !serder.snh || !serder.said) {
     throw new ValidationError("Delegated event is missing pre, sn, or said.");
@@ -110,6 +127,7 @@ function anchorData(serder: SerderKERI): { i: string; s: string; d: string } {
   return { i: serder.pre, s: serder.snh, d: serder.said };
 }
 
+/** Resolve delegate witnesses for either delegated inception or rotation. */
 function delegateWitnesses(
   hby: Habery,
   serder: SerderKERI,
@@ -123,6 +141,7 @@ function delegateWitnesses(
   return [...(hby.db.getKever(serder.pre)?.wits ?? [])];
 }
 
+/** Return true once the delegated event has left escrow and reached local state. */
 function delegateCommitted(
   hby: Habery,
   serder: SerderKERI,
@@ -134,6 +153,7 @@ function delegateCommitted(
   return kever !== undefined && kever !== null && kever.sn >= (serder.sn ?? 0);
 }
 
+/** Build a witness log query used to pull delegate-side completion material. */
 function delegateWitnessLogsQuery(
   hab: Hab,
   serder: SerderKERI,
@@ -159,6 +179,7 @@ function delegateWitnessLogsQuery(
   };
 }
 
+/** Route query cues through query transport and other cues through Respondant. */
 function delegateConfirmSink(
   runtime: AgentRuntime,
   hby: Habery,
@@ -176,6 +197,7 @@ function delegateConfirmSink(
   };
 }
 
+/** Approve pending delegated events for the selected local delegator habitat. */
 export function* delegateConfirmCommand(
   args: Record<string, unknown>,
 ): Operation<void> {
@@ -255,6 +277,9 @@ export function* delegateConfirmCommand(
 
         for (const serder of selected) {
           const anchor = anchorData(serder);
+          // KERIpy permits either interaction or rotation approval. Keep this
+          // explicit because the chosen approving event type affects later
+          // replay, but the embedded anchor seal is the same.
           if (interactionApproval) {
             hab.interact({ data: [anchor] });
           } else {
@@ -287,6 +312,9 @@ export function* delegateConfirmCommand(
           const witnesses = delegateWitnesses(hby, serder).sort();
           const selectedWitness = witnesses[0];
           if (selectedWitness) {
+            // Witnessed delegates must prove the delegated event is committed
+            // locally before we pin `aess.` and retry delegated unescrow. Doing
+            // it earlier can make local state look approved but incomplete.
             yield* sink.send(
               delegateWitnessLogsQuery(hab, serder, selectedWitness),
             );

--- a/packages/keri/src/app/cli/notifications.ts
+++ b/packages/keri/src/app/cli/notifications.ts
@@ -1,3 +1,10 @@
+/**
+ * Local notification CLI commands.
+ *
+ * These commands intentionally reopen the `Notifier` sidecar for one bounded
+ * operation and close both sidecar and `Habery` afterward. They are operator
+ * inspection/mutation tools, not protocol delegation approval commands.
+ */
 import { type Operation } from "npm:effection@^3.6.0";
 import { ValidationError } from "../../core/errors.ts";
 import type { Habery } from "../habbing.ts";
@@ -35,6 +42,7 @@ function requireRid(rid?: string): string {
   return rid;
 }
 
+/** Open the signed notification facade for one CLI invocation. */
 function* openNotifier(args: NotificationsOpenArgs): Operation<{
   hby: Habery;
   notifier: Notifier;
@@ -59,6 +67,7 @@ function* openNotifier(args: NotificationsOpenArgs): Operation<{
   };
 }
 
+/** Print verified local controller notices as JSON for operator inspection. */
 export function* notificationsListCommand(
   args: Record<string, unknown>,
 ): Operation<void> {
@@ -100,6 +109,7 @@ export function* notificationsListCommand(
   }
 }
 
+/** Mark one verified notice as read and persist its new detached signature. */
 export function* notificationsMarkReadCommand(
   args: Record<string, unknown>,
 ): Operation<void> {
@@ -125,6 +135,7 @@ export function* notificationsMarkReadCommand(
   }
 }
 
+/** Remove one verified notice from the notification sidecar. */
 export function* notificationsRemoveCommand(
   args: Record<string, unknown>,
 ): Operation<void> {

--- a/packages/keri/src/app/delegating.ts
+++ b/packages/keri/src/app/delegating.ts
@@ -1,3 +1,17 @@
+/**
+ * Delegation request handling and delegated-event approval workflow support.
+ *
+ * KERIpy correspondence:
+ * - `DelegateRequestHandler` mirrors the notification-facing exchange handler
+ *   in `keri.app.delegating`
+ * - `Anchorer` mirrors the approval workflow role of KERIpy's `Anchorer`
+ *
+ * `keri-ts` difference:
+ * - workflow progress is explicit turn-based escrow processing instead of a
+ *   long-lived HIO doer
+ * - proxy communication is a selected local habitat, not an implicit runtime
+ *   side effect
+ */
 import { type Operation } from "npm:effection@^3.6.0";
 import { Diger, type SerderKERI } from "../../../cesr/mod.ts";
 import { ValidationError } from "../core/errors.ts";
@@ -12,13 +26,17 @@ import type { QueryCoordinator } from "./querying.ts";
 import { sendWitnessMessage } from "./witnessing.ts";
 
 export const DELEGATE_REQUEST_ROUTE = "/delegate/request";
+
+/** Runtime passes to wait between repeated delegator-witness anchor queries. */
 const DELEGATION_ANCHOR_QUERY_RETRY_PASSES = 8;
 
+/** Durable phase for one delegated event as it moves through approval. */
 export type DelegationPhase =
   | "waitingWitnessReceipts"
   | "waitingDelegatorAnchor"
   | "waitingWitnessPublication";
 
+/** One turn-level workflow outcome emitted by `Anchorer.processAllOnce()`. */
 export type DelegationWorkflowResult =
   | {
     kind: "keep";
@@ -56,6 +74,7 @@ export interface DelegationWorkflowStatus {
   complete: boolean;
 }
 
+/** Internal escrow tuple with the durable key and required event fields split out. */
 type DelegationEscrowContext = [
   keys: [string, string],
   serder: SerderKERI,
@@ -73,6 +92,7 @@ function eventKey(serder: SerderKERI): [string, string] {
   return [pre, snh];
 }
 
+/** Build the anchor seal shape a delegator must embed in its approving event. */
 function eventAnchor(serder: SerderKERI): { i: string; s: string; d: string } {
   if (!serder.pre || !serder.snh || !serder.said) {
     throw new ValidationError(
@@ -82,6 +102,7 @@ function eventAnchor(serder: SerderKERI): { i: string; s: string; d: string } {
   return { i: serder.pre, s: serder.snh, d: serder.said };
 }
 
+/** Resolve the local habitat that owns the delegated event being processed. */
 function workflowHab(hby: Habery, serder: SerderKERI): Hab {
   const pre = serder.pre;
   if (!pre) {
@@ -135,6 +156,7 @@ function escrowContext(
   return [keys, serder, pre, said, snh];
 }
 
+/** Persist the delegator event seal that authorizes one delegated event. */
 function pinAuthorizingSeal(
   hby: Habery,
   delegated: SerderKERI,
@@ -167,6 +189,7 @@ function witnessReceiptsComplete(hby: Habery, serder: SerderKERI): boolean {
   return hby.db.wigs.get(dgKey(pre, said)).length >= kever.wits.length;
 }
 
+/** Resolve the delegator prefix from event material or accepted delegated state. */
 function delegatedWorkflowDelpre(
   hby: Habery,
   serder: SerderKERI,
@@ -178,6 +201,7 @@ function delegatedWorkflowDelpre(
   return (hab ?? workflowHab(hby, serder)).kever?.delpre ?? null;
 }
 
+/** Return the local delegator event that contains the delegated event seal. */
 function approvingEvent(
   hby: Habery,
   serder: SerderKERI,
@@ -213,6 +237,7 @@ export function resolveDelegationCommunicationHab(
   return hab;
 }
 
+/** Install delegation-specific EXN handlers into one exchange router. */
 export function loadDelegationHandlers(
   hby: Habery,
   exchanger: Exchanger,
@@ -265,6 +290,7 @@ export class DelegateRequestHandler implements ExchangeRouteHandler {
       && embeds?.["evt"] !== null;
   }
 
+  /** Store a signed controller notification when this request targets a local delegator. */
   handle(args: {
     serder: SerderKERI;
     attachments: ExchangeAttachment[];
@@ -365,6 +391,7 @@ export class Anchorer {
     }
   }
 
+  /** Begin workflow processing from the currently accepted event for an AID. */
   beginLatest(
     pre: string,
     sn?: number,
@@ -391,6 +418,7 @@ export class Anchorer {
     return serder;
   }
 
+  /** Return the current durable workflow phase without mutating escrow state. */
   workflowStatus(
     pre: string,
     snh: string,
@@ -420,6 +448,7 @@ export class Anchorer {
     };
   }
 
+  /** Return true after the delegated event has been durably completed. */
   complete(pre: string, sn: number | string): boolean {
     const snNum = typeof sn === "number" ? sn : parseInt(sn, 16);
     if (!Number.isInteger(snNum) || snNum < 0) {
@@ -438,6 +467,7 @@ export class Anchorer {
     return false;
   }
 
+  /** Process all delegation escrow families once in KERIpy-compatible order. */
   *processAllOnce(): Operation<DelegationWorkflowResult[]> {
     const results: DelegationWorkflowResult[] = [];
     for (
@@ -529,6 +559,9 @@ export class Anchorer {
       };
     }
 
+    // Do not ask the delegator to approve until the delegate's own witnesses
+    // have receipted the event. That preserves the KERIpy approval ordering
+    // and avoids anchoring an event the delegate cannot yet complete.
     const message = eventPayloadMessage(this.hby, serder);
     yield* this.poster.sendExchange(communicationHab, {
       recipient: delpre,
@@ -603,6 +636,9 @@ export class Anchorer {
       };
     }
 
+    // The approving event is authoritative only after the delegator's sealing
+    // event is learned locally; pinning `aess.` is what lets delegated unescrow
+    // and later reopen paths prove the authorization.
     pinAuthorizingSeal(this.hby, serder, delegating);
     this.hby.db.dune.rem(keys);
 
@@ -701,6 +737,7 @@ export class Anchorer {
     this.anchorQueryRetryPasses.set(id, -1);
   }
 
+  /** Retry bounded delegator-witness queries while waiting for the anchor. */
   private retryDelegatorWitnessQuery(
     serder: SerderKERI,
     communicationHab: Hab,
@@ -772,6 +809,8 @@ export class Anchorer {
       );
     }
 
+    // Publish the delegator chain first, then replay the approving event. This
+    // matches the witness-visible material KERIpy sends for delegated approval.
     for (const msg of this.hby.db.cloneDelegation(kever)) {
       for (const witness of kever.wits) {
         yield* sendWitnessMessage(hab, witness, msg);

--- a/packages/keri/src/app/forwarding.ts
+++ b/packages/keri/src/app/forwarding.ts
@@ -639,6 +639,9 @@ function hostCanStoreForwardRecipient(
   recipientKever: Kever,
   hostAid: string,
 ): boolean {
+  // A local host may store forwarded traffic only when it is an authorized
+  // witness/mailbox/agent for the recipient. This keeps mailbox storage from
+  // becoming a generic unauthenticated relay.
   if (recipientKever.wits.includes(hostAid)) {
     return true;
   }
@@ -658,6 +661,8 @@ function hasLocalStoreForwardHost(
   recipient: string,
   recipientKever: Kever,
 ): boolean {
+  // Check all local prefixes because a multi-role runtime can host a mailbox
+  // AID that is distinct from the controller currently processing the EXN.
   for (const hostAid of hby.db.prefixes) {
     if (hostCanStoreForwardRecipient(hby, recipient, recipientKever, hostAid)) {
       return true;
@@ -1088,6 +1093,8 @@ function extractForwardedMessage(
     return null;
   }
 
+  // Rebuild the embedded event from SAD plus only the attachment material
+  // pathed to `/e/evt`; other pathed groups belong to the outer `/fwd` message.
   const embedded = new SerderKERI({ sad: evt as Record<string, unknown> });
   const messageParts: Uint8Array[] = [embedded.raw];
 

--- a/packages/keri/src/app/notifying.ts
+++ b/packages/keri/src/app/notifying.ts
@@ -1,3 +1,15 @@
+/**
+ * Controller notification policy on top of the durable `Noter` sidecar.
+ *
+ * KERIpy correspondence:
+ * - mirrors the high-level responsibilities of `keri.app.notifying.Notifier`
+ * - persistent notice bytes and signatures live in `db/noting.ts`
+ *
+ * Maintainer rule:
+ * - notifications are signed local controller records, not protocol authority
+ * - delegation approval must use delegation escrows; `/notification` signals
+ *   are only transient UI wakeups.
+ */
 import { type Operation } from "npm:effection@^3.6.0";
 import { type Cigar } from "../../../cesr/mod.ts";
 import { ValidationError } from "../core/errors.ts";
@@ -25,6 +37,7 @@ export function notice<T extends NoticeAttrs = NoticeAttrs>(
   });
 }
 
+/** Derive sidecar-open options from the owning `Habery` path/layout settings. */
 export function noterOptionsForHabery(
   hby: Habery,
   options: Partial<NoterOptions> = {},
@@ -41,6 +54,7 @@ export function noterOptionsForHabery(
   };
 }
 
+/** Open the notification sidecar that belongs to one `Habery`. */
 export function* openNoterForHabery(
   hby: Habery,
   options: Partial<NoterOptions> = {},
@@ -50,6 +64,10 @@ export function* openNoterForHabery(
 
 /**
  * Signed durable controller notifications with transient `/notification` pings.
+ *
+ * The detached signature is verified on every read/mutation path so operators
+ * can trust CLI output even though notification payloads are intentionally
+ * application-specific maps.
  */
 export class Notifier {
   readonly hby: Habery;
@@ -71,6 +89,7 @@ export class Notifier {
     this.signaler = signaler ?? new Signaler();
   }
 
+  /** Add one unread signed notice and emit a transient add signal. */
   add<T extends NoticeAttrs = NoticeAttrs>(attrs: T): boolean {
     const signator = this.requireSignator();
     const note = notice(attrs);
@@ -83,6 +102,7 @@ export class Notifier {
     return true;
   }
 
+  /** List verified notices in durable datetime order. */
   list<T extends NoticeAttrs = NoticeAttrs>(
     start = 0,
     limit = 25,
@@ -92,10 +112,12 @@ export class Notifier {
     );
   }
 
+  /** Count durable notices without verifying each payload. */
   count(): number {
     return this.noter.countNotices();
   }
 
+  /** Mark one notice read and re-sign its updated pad. */
   markRead(rid: string): boolean {
     const [note] = this.requireNoticePair(rid);
     if (note.read) {
@@ -113,6 +135,7 @@ export class Notifier {
     return true;
   }
 
+  /** Remove one verified notice and emit a transient remove signal. */
   remove(rid: string): boolean {
     const [note] = this.requireNoticePair(rid);
     if (!this.noter.removeNotice(rid)) {

--- a/packages/keri/src/core/eventing.ts
+++ b/packages/keri/src/core/eventing.ts
@@ -302,6 +302,10 @@ export class Kevery {
           return escrowQuery("notFullyWitnessed");
         }
 
+        // Reopened validators may have accepted a delegated event before its
+        // `.aess` source-seal hint was learned. Repair that hint before replay
+        // so downstream receivers get the same delegation attachment KERIpy
+        // would clone from persisted delegating-event state.
         this.repairReplaySourceSeal(kever);
         const msgs = [...this.db.clonePreIter(pre, fn)];
         if (kever.delpre) {
@@ -782,6 +786,9 @@ export class Kevery {
     }
 
     const duplicateSaid = this.db.kels.getLast(pre, sn);
+    // A duplicate accepted event may still carry late source-seal or receipt
+    // attachments. Preserve those through the duplicate path instead of
+    // rejecting the whole replay as already-seen.
     if (duplicateSaid && duplicateSaid === said && sn <= kever.sn) {
       return this.buildDuplicateDecision(kever, init);
     }
@@ -1256,6 +1263,9 @@ export class Kevery {
   ): void {
     const habord = this.db.getHab(kever.pre);
     if (habord?.mid) {
+      // Group habitats can be learned through remote traffic after reopen.
+      // Keep the live group-prefix indexes synchronized with durable habitat
+      // records before protected-party cue policy runs.
       this.db.prefixes.add(kever.pre);
       this.db.groups.add(kever.pre);
     }
@@ -2518,6 +2528,13 @@ export class Kevery {
     };
   }
 
+  /**
+   * Decide whether a duplicate event's attached source seal is safe to store.
+   *
+   * Duplicate replay is intentionally narrow: only an existing delegated
+   * establishment event may learn a late source seal, and the seal must name
+   * the exact delegator event already known to anchor this delegate event.
+   */
   private validDuplicateSourceSeal(
     kever: Kever,
     serder: SerderKERI,
@@ -2540,6 +2557,14 @@ export class Kevery {
       && anchoring.said === sourceSeal.d.qb64;
   }
 
+  /**
+   * Backfill `.aess` for an accepted delegated establishment before replay.
+   *
+   * KERIpy clones delegation attachments from durable state during replay.
+   * `keri-ts` keeps replay construction decoupled, so this helper repairs the
+   * accepted source-seal index from the delegator's sealing event when the
+   * event body was accepted before the hint was persisted.
+   */
   private repairReplaySourceSeal(kever: Kever): void {
     const serder = kever.serder;
     const pre = serder.pre;
@@ -2568,6 +2593,14 @@ export class Kevery {
     ]);
   }
 
+  /**
+   * Repair accepted delegated events after a delegator event is accepted.
+   *
+   * When the newly accepted event contains delegation anchors, any already
+   * stored delegate establishment it names can learn the corresponding
+   * source-seal hint immediately. This keeps later duplicate/replay handling
+   * deterministic without rerunning full event acceptance.
+   */
   private repairAnchoredDelegationSourceSeals(serder: SerderKERI): void {
     const delpre = serder.pre;
     const said = serder.said;
@@ -2602,6 +2635,13 @@ export class Kevery {
     }
   }
 
+  /**
+   * Repair source-seal hints for escrowed delegated establishment events.
+   *
+   * Escrow reprocessing may encounter a delegate event after the approving
+   * delegator event was already accepted. This helper converts that discovered
+   * anchor into the same `.aess` hint carried by live source-seal attachments.
+   */
   private repairEscrowDelegationSourceSeal(serder: SerderKERI): void {
     const pre = serder.pre;
     const said = serder.said;

--- a/packages/keri/src/core/kever.ts
+++ b/packages/keri/src/core/kever.ts
@@ -1209,6 +1209,9 @@ export class Kever {
     // for escrow. Misfit checks come first so locally protected events do not
     // leak into a more permissive partial-signature or partial-delegation
     // class.
+    // A local delegator reviewing someone else's delegated establishment is a
+    // protected-party case, but it must enter `delegables` until the local
+    // approval interaction/rotation is actually attached as a source seal.
     const localDelegatorApprovalCandidate = (input.serder.ilk === Ilks.dip || input.serder.ilk === Ilks.drt)
       && this.locallyDelegated(delpre)
       && !this.locallyOwned();
@@ -1382,6 +1385,9 @@ export class Kever {
     // A local delegator without an attached approval seal is not a generic
     // partial-delegation case. It is specifically waiting for local
     // out-of-band approval to be attached and reprocessed.
+    // Local approval is represented by a real, already accepted delegator
+    // event. The attached source seal is only authoritative when it resolves
+    // to that accepted event and that event's anchors name this delegate event.
     const sourceSealApprovesEvent = input.sourceSeal
       ? this.lookupAcceptedDelegatingEvent(
         delpre,
@@ -1768,6 +1774,9 @@ export class Kever {
     if (!candidate || !candidate.said || candidate.sn === null) {
       return null;
     }
+    // Accepted first-seen state is the primary signal, but restored KELs may
+    // have authoritative sequence membership before first-seen metadata has
+    // been reconstructed. Accept either durable signal for approval lookup.
     const accepted = !!this.db.fons.get(dgKey(delpre, candidate.said))
       || this.db.kels.getLast(delpre, candidate.sn) === candidate.said;
     if (!accepted) return null;

--- a/packages/keri/src/core/protocol-eventing.ts
+++ b/packages/keri/src/core/protocol-eventing.ts
@@ -1,3 +1,11 @@
+/**
+ * KERI event factory helpers.
+ *
+ * These functions own the typed construction boundary for KERI KEL SADs:
+ * callers provide semantic options, while this module preserves KERIpy field
+ * order, threshold normalization, witness-set derivation, and SAID code
+ * selection before `SerderKERI` makification.
+ */
 import {
   DigDex,
   DIGEST_CODES,
@@ -147,6 +155,13 @@ function encodeCount(
   return intive && value <= MAX_INTIVE_THRESHOLD ? value : value.toString(16);
 }
 
+/**
+ * Resolve `d` and `i` SAID codes for inception-like events before makification.
+ *
+ * The prefix code may be caller-specified, already present in the KED, or left
+ * as the digest default. Keeping this normalization here prevents habitat and
+ * CLI layers from encoding KERIpy SAID-code policy themselves.
+ */
 function resolveInceptiveSaidCodes(
   ked: Record<string, unknown>,
   explicitPrefixCode?: string,

--- a/packages/keri/src/core/protocol-vdr-eventing.ts
+++ b/packages/keri/src/core/protocol-vdr-eventing.ts
@@ -1,3 +1,10 @@
+/**
+ * KERI VDR event factory helpers.
+ *
+ * Registry and credential-state events are smaller than KEL events but carry
+ * the same invariants: stable KERIpy-compatible field order, threshold/backer
+ * validation, and semantic seal projection before `SerderKERI` computes SAIDs.
+ */
 import {
   Ilks,
   type Kind,
@@ -36,6 +43,7 @@ function cloneStrings(values?: readonly string[]): string[] {
   return [...(values ?? [])];
 }
 
+/** Project a typed event seal into the SAD dictionary shape used by VDR events. */
 function cloneSealDict(seal?: SealEvent): Record<string, unknown> {
   if (!seal) {
     return {};

--- a/packages/keri/src/db/noting.ts
+++ b/packages/keri/src/db/noting.ts
@@ -40,10 +40,12 @@ function randomNonce(): string {
   return new Salter({ code: MtrDex.Salt_128, raw }).qb64;
 }
 
+/** Serialize notice pads as the signed bytes persisted in `nots.`. */
 function encodePad<T extends object>(pad: T): Uint8Array {
   return textEncoder.encode(JSON.stringify(pad));
 }
 
+/** Decode stored notice bytes back into their mutable pad representation. */
 function decodePad<T extends object>(raw: Uint8Array): T {
   return JSON.parse(textDecoder.decode(raw)) as T;
 }
@@ -166,6 +168,7 @@ export class Noter extends LMDBer {
   static override readonly TempPrefix = "keri_not_";
   static override readonly MaxNamedDBs = 8;
 
+  /** Select `.tufa/not` by default while preserving `.keri/not` compat mode. */
   constructor(options: NoterOptions = {}) {
     const compat = options.compat ?? false;
     super(options, {
@@ -180,6 +183,7 @@ export class Noter extends LMDBer {
     });
   }
 
+  /** Open all notice, reverse-index, and detached-signature families. */
   override *reopen(
     options: Partial<NoterOptions> = {},
   ) {

--- a/packages/keri/test/integration/app/interop-delegation-group-kli-tufa.test.ts
+++ b/packages/keri/test/integration/app/interop-delegation-group-kli-tufa.test.ts
@@ -77,6 +77,7 @@ interface TufaGeneratedGroupEvent {
   message?: Uint8Array;
 }
 
+/** Bridge a Promise into the Effection operation used by runtime helpers. */
 function* awaitPromise<T>(promise: Promise<T>): Operation<T> {
   return yield* action<T>((resolve, reject) => {
     promise.then(resolve, reject);
@@ -84,6 +85,7 @@ function* awaitPromise<T>(promise: Promise<T>): Operation<T> {
   });
 }
 
+/** Ask one Tufa witness host to receipt a serialized group event. */
 function* requestTufaWitnessReceipt(
   witness: TufaWitnessNode,
   message: Uint8Array,
@@ -109,6 +111,7 @@ function* requestTufaWitnessReceipt(
   return body;
 }
 
+/** Parse KLI output across command variants that say either Prefix or Identifier. */
 function extractKliIdentifier(output: string): string {
   try {
     return extractPrefix(output);
@@ -121,6 +124,7 @@ function extractKliIdentifier(output: string): string {
   }
 }
 
+/** Generate a role-specific Tufa OOBI through the CLI. */
 async function generateTufaOobi(
   ctx: InteropContext,
   args: {
@@ -159,6 +163,12 @@ async function generateTufaOobi(
   return extractLastNonEmptyLine(result.stdout);
 }
 
+/**
+ * Create one witnessed KLI participant with mailbox routing enabled.
+ *
+ * The participant is suitable for both multisig member traffic and delegation
+ * proxy delivery because witness and mailbox OOBIs are both advertised.
+ */
 async function createKliParticipant(
   ctx: InteropContext,
   args: {
@@ -220,6 +230,7 @@ async function createKliParticipant(
   };
 }
 
+/** Teach one KLI participant how to reach another participant's mailbox. */
 async function resolveKliParticipantOobis(
   ctx: InteropContext,
   participant: KliParticipant,
@@ -234,6 +245,7 @@ async function resolveKliParticipantOobis(
   });
 }
 
+/** Create one witnessed Tufa AID with mailbox routing enabled. */
 async function createTufaAIDWithMailbox(
   ctx: InteropContext,
   args: {
@@ -310,6 +322,7 @@ async function createTufaAIDWithMailbox(
   };
 }
 
+/** Teach a Tufa controller how to reach a KLI participant mailbox. */
 async function resolveTufaKnownKliParticipant(
   ctx: InteropContext,
   tufa: TufaAID,
@@ -325,6 +338,7 @@ async function resolveTufaKnownKliParticipant(
   });
 }
 
+/** Teach a KLI participant how to reach a Tufa controller mailbox. */
 async function resolveKliKnownTufaAID(
   ctx: InteropContext,
   kli: KliParticipant | {
@@ -343,6 +357,7 @@ async function resolveKliKnownTufaAID(
   });
 }
 
+/** Write the KLI multisig config that delegates the group to a Tufa AID. */
 async function writeKliMultisigConfig(args: {
   member1: KliParticipant;
   member2: KliParticipant;
@@ -373,6 +388,7 @@ async function writeKliMultisigConfig(args: {
   return file;
 }
 
+/** Start the KLI multisig join side and leave it running until completion. */
 function spawnKliMultisigJoin(
   ctx: InteropContext,
   participant: KliParticipant,
@@ -397,6 +413,7 @@ function spawnKliMultisigJoin(
   );
 }
 
+/** Start the KLI multisig incept side and leave it running until completion. */
 function spawnKliMultisigIncept(
   ctx: InteropContext,
   participant: KliParticipant,
@@ -427,6 +444,13 @@ function spawnKliMultisigIncept(
   );
 }
 
+/**
+ * Build the full KLI group-delegate to Tufa-delegator fixture.
+ *
+ * This uses only public KLI commands for the KERIpy side, then resolves enough
+ * cross-OOBIs for multisig coordination, mailbox transport, and delegation
+ * confirmation to run without hidden store mutations.
+ */
 async function setupKliGroupDelegateToTufaDelegator(args: {
   ctx: InteropContext;
   base: string;
@@ -511,6 +535,7 @@ async function setupKliGroupDelegateToTufaDelegator(args: {
   }
 }
 
+/** Wait until the Tufa delegator has escrowed the KLI group event in `delegables`. */
 async function waitForTufaDelegable(
   delegator: TufaAID,
 ): Promise<TufaGeneratedGroupEvent> {
@@ -540,6 +565,7 @@ async function waitForTufaDelegable(
   return event;
 }
 
+/** Approve the current Tufa `delegables` item through the CLI confirmation path. */
 async function approveTufaDelegableWithTufaCli(
   ctx: InteropContext,
   delegator: TufaAID,
@@ -570,6 +596,7 @@ async function approveTufaDelegableWithTufaCli(
   assertStringIncludes(result.stdout, "Approved delegated dip");
 }
 
+/** Wait for both KLI multisig processes and require them to agree on the group AID. */
 async function waitForKliGroupCompletion(args: {
   member1: KliParticipant;
   member2: KliParticipant;
@@ -586,6 +613,7 @@ async function waitForKliGroupCompletion(args: {
   return inceptPrefix;
 }
 
+/** Generate a Tufa group event without accepting it so the test can wire receipts. */
 function makeTufaGeneratedGroupEvent(
   hby: Habery,
   args: {
@@ -627,6 +655,13 @@ function makeTufaGeneratedGroupEvent(
   };
 }
 
+/**
+ * Generate a Tufa delegated group event and post the request to a KLI delegator.
+ *
+ * The event is optionally receipted by a live Tufa witness first, then sent both
+ * as an embedded delegation request and as raw mailbox bytes so the KLI side can
+ * satisfy the same event-payload and replay paths it uses in production.
+ */
 async function postTufaGroupDelegationRequest(args: {
   store: TufaAID;
   member1Alias: string;
@@ -663,6 +698,9 @@ async function postTufaGroupDelegationRequest(args: {
         if (!message) {
           throw new Error("Expected Tufa group delegation message bytes.");
         }
+        // Witness receipts are ingested before extracting the wire payload so
+        // the embedded event includes the indexed witness signatures that KLI
+        // expects for a witnessed delegated group inception.
         const receiptMessage = args.witness
           ? yield* requestTufaWitnessReceipt(args.witness, message)
           : null;
@@ -706,6 +744,7 @@ async function postTufaGroupDelegationRequest(args: {
   });
 }
 
+/** Create a KLI delegator through the participant helper for naming clarity. */
 async function createKliDelegatorWithMailbox(
   ctx: InteropContext,
   args: {

--- a/packages/keri/test/integration/app/interop-delegation-helpers.ts
+++ b/packages/keri/test/integration/app/interop-delegation-helpers.ts
@@ -1,3 +1,11 @@
+/**
+ * Delegation-focused helpers for live KLI/Tufa interop scenarios.
+ *
+ * The helpers here encode the cross-implementation setup contract: isolated
+ * stores, explicit OOBI resolution, hosted controller/mailbox routes, witness
+ * startup, and bounded runtime pumping. Scenario files should use these helpers
+ * so protocol assertions stay separate from subprocess plumbing.
+ */
 import { type Operation, run } from "npm:effection@^3.6.0";
 import { type AgentRuntime, createAgentRuntime, processRuntimeUntil } from "../../../src/app/agent-runtime.ts";
 import { createHabery, type Hab, type Habery } from "../../../src/app/habbing.ts";
@@ -20,6 +28,7 @@ import {
 export const INTEROP_PASSCODE = "MyPasscodeARealSecret";
 export const INTEROP_SALT = "0AAwMTIzNDU2Nzg5YWJjZGVm";
 
+/** Common Tufa controller store metadata used across live delegation tests. */
 export interface TufaStoreRef {
   name: string;
   base: string;
@@ -29,6 +38,7 @@ export interface TufaStoreRef {
   pre: string;
 }
 
+/** Common KLI controller store metadata used across live delegation tests. */
 export interface KliStoreRef {
   name: string;
   base: string;
@@ -37,6 +47,7 @@ export interface KliStoreRef {
   pre: string;
 }
 
+/** Running Tufa mailbox provider plus OOBIs advertised to remote controllers. */
 export interface TufaMailboxProviderFixture extends TufaStoreRef {
   origin: string;
   controllerOobi: string;
@@ -44,12 +55,14 @@ export interface TufaMailboxProviderFixture extends TufaStoreRef {
   close(): Promise<void>;
 }
 
+/** Runtime snapshot exposed to polling predicates while pumping a Tufa store. */
 export interface TufaRuntimeSnapshot {
   hby: Habery;
   runtime: AgentRuntime;
   hab?: Hab;
 }
 
+/** Initialize a Tufa store through the CLI under the shared interop env. */
 export async function initTufaStore(
   ctx: InteropContext,
   args: {
@@ -81,6 +94,7 @@ export async function initTufaStore(
   );
 }
 
+/** Incept one Tufa alias and return the emitted prefix line. */
 export async function inceptTufaAlias(
   ctx: InteropContext,
   args: {
@@ -145,6 +159,7 @@ export async function inceptTufaAlias(
   return extractPrefixLine(result.stdout);
 }
 
+/** Initialize a KERIpy store, allowing pyenv-backed startup to settle. */
 export async function initKliStore(
   ctx: InteropContext,
   args: {
@@ -174,6 +189,7 @@ export async function initKliStore(
   );
 }
 
+/** Incept one KLI alias and return the emitted prefix line. */
 export async function inceptKliAlias(
   ctx: InteropContext,
   args: {
@@ -230,6 +246,12 @@ export async function inceptKliAlias(
   return extractPrefixLine(result.stdout);
 }
 
+/**
+ * Add controller and optional mailbox endpoint roles for a Tufa-hosted AID.
+ *
+ * Endpoint role replies are what make later mailbox/direct-delivery OOBIs
+ * meaningful to the opposite implementation.
+ */
 export async function addTufaHostedRoute(
   ctx: InteropContext,
   args: {
@@ -321,6 +343,7 @@ export async function addTufaHostedRoute(
   );
 }
 
+/** Add controller and optional mailbox endpoint roles for a KLI-hosted AID. */
 export async function addKliHostedRoute(
   ctx: InteropContext,
   args: {
@@ -393,6 +416,7 @@ export async function addKliHostedRoute(
   );
 }
 
+/** Resolve an OOBI into a Tufa store and wait for the command to finish. */
 export async function resolveTufaOobi(
   ctx: InteropContext,
   args: {
@@ -430,6 +454,7 @@ export async function resolveTufaOobi(
   );
 }
 
+/** Resolve an OOBI into a KLI store and wait for the command to finish. */
 export async function resolveKliOobi(
   ctx: InteropContext,
   args: {
@@ -464,6 +489,7 @@ export async function resolveKliOobi(
   );
 }
 
+/** Register an already-resolved mailbox provider against a Tufa controller. */
 export async function addTufaMailbox(
   ctx: InteropContext,
   args: {
@@ -501,6 +527,7 @@ export async function addTufaMailbox(
   );
 }
 
+/** Register an already-resolved mailbox provider against a KLI controller. */
 export async function addKliMailbox(
   ctx: InteropContext,
   args: {
@@ -535,6 +562,7 @@ export async function addKliMailbox(
   );
 }
 
+/** Generate a mailbox OOBI for a Tufa controller alias. */
 export async function generateTufaMailboxOobi(
   ctx: InteropContext,
   args: {
@@ -572,6 +600,7 @@ export async function generateTufaMailboxOobi(
   return extractLastNonEmptyLine(result.stdout);
 }
 
+/** Generate a mailbox OOBI for a KLI controller alias. */
 export async function generateKliMailboxOobi(
   ctx: InteropContext,
   args: {
@@ -606,6 +635,7 @@ export async function generateKliMailboxOobi(
   return extractLastNonEmptyLine(result.stdout);
 }
 
+/** Start a Tufa agent host and fail with captured output if health never opens. */
 export async function startTufaAgentHost(
   ctx: InteropContext,
   args: {
@@ -651,6 +681,7 @@ export async function startTufaAgentHost(
   return child;
 }
 
+/** Start a KERIpy mailbox host and fail with captured output if health never opens. */
 export async function startKliMailboxHost(
   ctx: InteropContext,
   args: {
@@ -692,6 +723,12 @@ export async function startKliMailboxHost(
   return child;
 }
 
+/**
+ * Provision a non-transferable Tufa mailbox provider fixture.
+ *
+ * The fixture advertises both controller and mailbox roles because delegation
+ * proxy traffic depends on endpoint routing, not just an HTTP health check.
+ */
 export async function setupTufaMailboxProvider(
   ctx: InteropContext,
   args: {
@@ -754,6 +791,7 @@ export async function setupTufaMailboxProvider(
   };
 }
 
+/** Retry a CLI action that can fail transiently while hosts finish startup. */
 export async function waitForEventuallySuccess(
   label: string,
   action: () => Promise<CmdResult>,
@@ -785,6 +823,7 @@ export async function waitForEventuallySuccess(
   );
 }
 
+/** Wait for a spawned subprocess and return combined output for assertions. */
 export async function waitForChildSuccess(
   label: string,
   child: SpawnedChild,
@@ -823,6 +862,12 @@ export async function waitForChildSuccess(
   return output;
 }
 
+/**
+ * Reopen a Tufa store, create a local runtime, and process turns until done.
+ *
+ * This mirrors what a live agent host would do while keeping tests deterministic
+ * and bounded around mailbox polling and escrow continuation.
+ */
 export async function pumpTufaRuntimeUntil(
   store: {
     name: string;
@@ -870,6 +915,7 @@ export async function pumpTufaRuntimeUntil(
   });
 }
 
+/** Inspect a Tufa store in readonly mode without starting runtime workers. */
 export async function inspectTufaHabery<T>(
   store: {
     name: string;
@@ -899,6 +945,7 @@ export async function inspectTufaHabery<T>(
   return value;
 }
 
+/** Inspect the accepted sequence number for a KLI-compatible store prefix. */
 export async function inspectCompatKeverSn(
   ctx: InteropContext,
   store: {

--- a/packages/keri/test/integration/app/interop-delegation-kli-tufa.test.ts
+++ b/packages/keri/test/integration/app/interop-delegation-kli-tufa.test.ts
@@ -46,6 +46,7 @@ import {
   startTufaWitnessHarness,
 } from "./interop-test-helpers.ts";
 
+/** JSON shape emitted by the Tufa notifications CLI in delegation scenarios. */
 interface NotificationList {
   total: number;
   start: number;
@@ -58,6 +59,7 @@ interface NotificationList {
   }>;
 }
 
+/** Delegate key material profile used to exercise single-key and threshold paths. */
 interface DelegateKeyProfile {
   label: string;
   inceptIsith: string;
@@ -83,10 +85,12 @@ const DELEGATE_KEY_PROFILES: readonly DelegateKeyProfile[] = [
   },
 ];
 
+/** Expected number of local signing keys generated for a delegate profile. */
 function expectedSigningKeyCount(profile: DelegateKeyProfile): number {
   return Number.parseInt(profile.inceptIcount, 10);
 }
 
+/** KLI rotation args that preserve the tested delegate threshold profile. */
 function kliRotateKeyArgs(profile: DelegateKeyProfile): string[] {
   return [
     "--isith",
@@ -98,6 +102,7 @@ function kliRotateKeyArgs(profile: DelegateKeyProfile): string[] {
   ];
 }
 
+/** Read delegation notification sidecars through the public Tufa CLI. */
 async function listTufaNotifications(args: {
   env: Record<string, string>;
   repoRoot: string;

--- a/packages/keri/test/integration/app/tufa-delegation-group-long.test.ts
+++ b/packages/keri/test/integration/app/tufa-delegation-group-long.test.ts
@@ -1,5 +1,13 @@
 // @file-test-lane runtime-slow
 
+/**
+ * Long-running Tufa multisig delegation stress scenario.
+ *
+ * This opt-in test exercises sustained delegated group rotation with weighted
+ * thresholds, changing signer membership, and repeated delegator anchoring.
+ * It is intentionally separate from the default lane because its value is
+ * protocol endurance rather than fast regression coverage.
+ */
 import { run } from "effection";
 import { assertEquals, assertExists } from "jsr:@std/assert";
 import {
@@ -20,6 +28,7 @@ import { messagize } from "../../../src/core/protocol-serialization.ts";
 import { HabitatRecord } from "../../../src/core/records.ts";
 import { dgKey } from "../../../src/db/core/keys.ts";
 
+/** Explicit opt-in guard for the slow multisig delegation endurance test. */
 const ENABLE_LONG_MULTISIG_DELEGATION = Deno.env.get("KERI_LONG_MULTISIG_DELEGATION") === "1";
 const GROUP_THRESHOLD: ThresholdSith = ["2/3", "2/3", "2/3"];
 const DELEGATE_EVENT_COUNT = 64;
@@ -47,6 +56,7 @@ function makeMember(hby: Habery, alias: string): Hab {
   });
 }
 
+/** Create a 2-of-3 weighted group, optionally delegated to another group. */
 function makeWeightedGroup(
   hby: Habery,
   alias: string,
@@ -76,6 +86,7 @@ function makeWeightedGroup(
   };
 }
 
+/** Resolve an accepted or escrowed event serder by prefix/sequence number. */
 function eventSerderFor(hby: Habery, pre: string, sn: number): SerderKERI {
   const said = hby.db.kels.getLast(pre, sn)
     ?? hby.db.pdes.getOn(pre, sn)[0]
@@ -93,6 +104,7 @@ function eventAnchor(serder: SerderKERI): { i: string; s: string; d: string } {
   return { i: serder.pre, s: serder.snh, d: serder.said };
 }
 
+/** Encode group member index tuples for durable group habitat sidecars. */
 function memberTuples(members: readonly Hab[]) {
   return members.map((member, index) =>
     [
@@ -102,6 +114,13 @@ function memberTuples(members: readonly Hab[]) {
   );
 }
 
+/**
+ * Persist current/next group membership sidecars after a synthetic rotation.
+ *
+ * Real CLI flows write these records while coordinating multisig operations;
+ * this direct test updates them explicitly so subsequent rotations validate
+ * against the intended current and prior-next member sets.
+ */
 function persistGroupMembers(group: GroupAid): void {
   const pre = group.hab.pre;
   const stored = group.hby.db.getHab(pre);
@@ -153,6 +172,7 @@ function priorNextIndexForKey(group: GroupAid, key: string): number {
   return index;
 }
 
+/** Sign a group event with current keys and, for rotations, prior-next indexes. */
 function signGroupEvent(
   group: GroupAid,
   serder: SerderKERI,
@@ -181,6 +201,7 @@ function signGroupEvent(
   return sigers;
 }
 
+/** Process a locally authored group event and return its pipelined message. */
 function processLocalGroupEvent(
   group: GroupAid,
   serder: SerderKERI,
@@ -230,6 +251,7 @@ function rotateMembers(members: readonly Hab[]): void {
   }
 }
 
+/** Rotate the delegated group to a new current/next member set. */
 function groupRotate(
   group: GroupAid,
   current: Hab[],
@@ -263,6 +285,12 @@ function groupRotate(
   );
 }
 
+/**
+ * Anchor one delegated event in the delegator KEL and process delegables.
+ *
+ * The source-seal hint is pinned exactly where live confirmation would store
+ * it, so the subsequent escrow promotion path matches the production flow.
+ */
 function anchorDelegatedEvent(delegator: GroupAid, delegated: SerderKERI) {
   const approval = groupInteract(delegator, [eventAnchor(delegated)]);
   assertExists(delegated.pre);
@@ -323,6 +351,8 @@ Deno.test({
         anchorDelegatedEvent(delegator, inception);
         assertEquals(hby.db.getKever(delegate.hab.pre)?.sn, 0);
 
+        // Rotate through several signer windows, then hold steady to prove
+        // later delegated rotations continue using repaired group sidecars.
         const membershipPlan = [
           [memberB, memberC, memberD],
           [memberC, memberD, memberE],

--- a/packages/keri/test/integration/app/tufa-delegation-group.test.ts
+++ b/packages/keri/test/integration/app/tufa-delegation-group.test.ts
@@ -1,5 +1,14 @@
 // @file-test-lane runtime-medium
 
+/**
+ * Tufa-only delegation matrix for single and group AIDs.
+ *
+ * These scenarios exercise the same issue-hold-approve protocol seams as the
+ * live KLI/Tufa tests without subprocess cost: delegation requests arrive over
+ * an explicit communication AID, local delegators escrow into `delegables`,
+ * approval pins source-seal hints, and replayed delegator KELs release partial
+ * delegation escrow for the delegate.
+ */
 import { run } from "effection";
 import { assertEquals, assertExists, assertStringIncludes } from "jsr:@std/assert";
 import { concatBytes, Counter, CtrDexV1, Diger, SerderKERI, Siger } from "../../../../cesr/mod.ts";
@@ -69,6 +78,7 @@ const MATRIX: readonly MatrixCase[] = [
   },
 ];
 
+/** Resolve an accepted or escrowed event serder by prefix/sequence number. */
 function eventSerderFor(hby: Habery, pre: string, sn = 0): SerderKERI {
   const said = hby.db.kels.getLast(pre, sn)
     ?? hby.db.pdes.getOn(pre, sn)[0]
@@ -79,6 +89,7 @@ function eventSerderFor(hby: Habery, pre: string, sn = 0): SerderKERI {
   return serder;
 }
 
+/** Convert an event serder into the anchor data carried by delegator events. */
 function eventAnchor(serder: SerderKERI): { i: string; s: string; d: string } {
   assertExists(serder.pre);
   assertExists(serder.snh);
@@ -86,6 +97,12 @@ function eventAnchor(serder: SerderKERI): { i: string; s: string; d: string } {
   return { i: serder.pre, s: serder.snh, d: serder.said };
 }
 
+/**
+ * Attach synthetic witness indexed receipts to a local event.
+ *
+ * This keeps the matrix focused on delegation behavior while still proving
+ * that witnessed delegated events carry and replay witness receipt attachments.
+ */
 function storeWitnessIndexedReceipts(
   hby: Habery,
   serder: SerderKERI,
@@ -127,6 +144,7 @@ function witnessCounter(count: number): string {
   );
 }
 
+/** Assert that a replayed message contains the expected witness signature group. */
 function assertHasWitnessIndexedSigs(message: Uint8Array, count: number): void {
   const serder = new SerderKERI({ raw: message });
   assertStringIncludes(
@@ -135,6 +153,7 @@ function assertHasWitnessIndexedSigs(message: Uint8Array, count: number): void {
   );
 }
 
+/** Build the `/delegate/request` exchange message used by delegation handlers. */
 function delegationRequestMessage(
   sender: Hab,
   delpre: string,
@@ -244,6 +263,7 @@ function createGroupAid(
   };
 }
 
+/** Create either a single-key or multisig local AID for the scenario matrix. */
 function createControlledAid(
   hby: Habery,
   alias: string,
@@ -260,6 +280,7 @@ function createControlledAid(
   return createGroupAid(hby, alias, profile, options);
 }
 
+/** Advance one runtime without polling mailboxes for a bounded number of turns. */
 function* drainRuntime(
   runtime: AgentRuntime,
   hab: Hab,
@@ -270,6 +291,7 @@ function* drainRuntime(
   }
 }
 
+/** Inject serialized messages and drain the runtime so escrows can settle. */
 function* ingestMessages(
   runtime: AgentRuntime,
   hab: Hab,
@@ -282,6 +304,7 @@ function* ingestMessages(
   yield* drainRuntime(runtime, hab, turns);
 }
 
+/** Replay one accepted KEL from a source store into a target runtime. */
 function* transferAcceptedKel(
   source: Habery,
   target: AgentRuntime,
@@ -291,6 +314,12 @@ function* transferAcceptedKel(
   yield* ingestMessages(target, targetHab, source.db.clonePreIter(pre), 12);
 }
 
+/**
+ * Approve one locally escrowed delegated event as a delegator.
+ *
+ * The explicit `.aess` pin mirrors the source-seal attachment that live
+ * delegate confirmation sends after the delegator interaction is accepted.
+ */
 function approveDelegable(
   delegator: ControlledAid,
   delegated: ControlledAid,
@@ -389,6 +418,8 @@ for (const spec of MATRIX) {
             communicationHab: delegateProxy,
           },
         );
+        // Group delegates communicate through a member/proxy AID rather than
+        // the group prefix itself, matching the live IPEX-style proxy path.
         const requestSender = spec.delegate.kind === "single"
           ? delegateProxy
           : delegated.communicationHab;

--- a/packages/tufa/scripts/build_npm.ts
+++ b/packages/tufa/scripts/build_npm.ts
@@ -1,3 +1,10 @@
+/**
+ * Build the `@keri-ts/tufa` npm package and normalize its CLI metadata.
+ *
+ * Tufa publishes both a minimal module surface and the `tufa` executable. DNT
+ * output paths can move as imports change, so generated entrypoint marker
+ * comments are used to discover package.json targets before packing.
+ */
 import { build, emptyDir } from "@deno/dnt";
 
 const ENTRYPOINT = "./src/npm/index.ts";
@@ -32,6 +39,7 @@ interface TufaNpmTargets {
 const ROOT_ENTRYPOINT_MARKER = "Minimal npm module surface for the `tufa` application package.";
 const BIN_ENTRYPOINT_MARKER = "run(() => tufa(argv.slice(2)))";
 
+/** Resolve this package version from its workspace package.json. */
 function resolvePackageVersion(): string {
   const raw = Deno.readTextFileSync("./package.json");
   const pkg = JSON.parse(raw) as PackageManifest;
@@ -42,6 +50,7 @@ function resolvePackageVersion(): string {
   return version;
 }
 
+/** Resolve an internal dependency version from a sibling workspace package. */
 function resolveWorkspacePackageVersion(path: string): string {
   const raw = Deno.readTextFileSync(path);
   const pkg = JSON.parse(raw) as PackageManifest;
@@ -52,6 +61,7 @@ function resolveWorkspacePackageVersion(path: string): string {
   return version;
 }
 
+/** Pin DNT's workspace imports to npm package specifiers for generated output. */
 function writeDntImportMap(
   keriVersion: string,
   cesrVersion: string,
@@ -71,6 +81,7 @@ function writeDntImportMap(
   );
 }
 
+/** Recursively list generated files so marker lookup survives DNT path drift. */
 function listFilesSync(dir: string): string[] {
   const files: string[] = [];
   for (const entry of Deno.readDirSync(dir)) {
@@ -84,10 +95,17 @@ function listFilesSync(dir: string): string[] {
   return files;
 }
 
+/** Convert an on-disk generated path into a package.json-relative target. */
 function toPackagePath(path: string): string {
   return `./${path.replace(`${OUT_DIR}/`, "")}`;
 }
 
+/**
+ * Locate exactly one generated entrypoint by filename and marker text.
+ *
+ * This prevents release artifacts from silently publishing stale hard-coded
+ * manifest paths when DNT changes emitted directory structure.
+ */
 function findGeneratedEntrypoint(
   root: string,
   fileName: string,
@@ -111,6 +129,7 @@ function findGeneratedEntrypoint(
   return toPackagePath(matches[0]);
 }
 
+/** Assert that a manifest/bin target points at a real file in the package. */
 function assertPackagePathExists(path: string): void {
   const relative = path.replace(/^\.\//, "");
   const fullPath = `${OUT_DIR}/${relative}`;
@@ -120,6 +139,7 @@ function assertPackagePathExists(path: string): void {
   }
 }
 
+/** Resolve module and CLI executable targets from generated output. */
 function resolveGeneratedTargets(): TufaNpmTargets {
   const targets = {
     root: {
@@ -148,6 +168,12 @@ function resolveGeneratedTargets(): TufaNpmTargets {
   return targets;
 }
 
+/**
+ * Rewrite DNT's manifest paths to the generated module and bare bin target.
+ *
+ * Node package `bin` entries are package-relative paths without a leading
+ * `./`, while exports keep `./` targets. Keep that policy centralized here.
+ */
 function normalizeBuiltManifest(): TufaNpmTargets {
   const packageJsonPath = `${OUT_DIR}/package.json`;
   const raw = Deno.readTextFileSync(packageJsonPath);
@@ -249,11 +275,15 @@ try {
     postBuild() {
       const targets = normalizeBuiltManifest();
       try {
+        // DNT can inline workspace source trees for local imports; published
+        // Tufa should depend on npm packages instead of carrying duplicate
+        // generated keri/cesr implementation trees.
         Deno.removeSync(`${OUT_DIR}/esm/keri`, { recursive: true });
       } catch {
         // no-op
       }
       try {
+        // See the keri tree removal above.
         Deno.removeSync(`${OUT_DIR}/esm/cesr`, { recursive: true });
       } catch {
         // no-op
@@ -264,6 +294,8 @@ try {
       const binPath = `${OUT_DIR}/${targets.bin.replace(/^\.\//, "")}`;
       const current = Deno.readTextFileSync(binPath);
       if (!current.startsWith("#!/usr/bin/env node\n")) {
+        // DNT emits an ESM file; npm executables still need a shebang and
+        // executable mode for global installs and Docker smoke tests.
         Deno.writeTextFileSync(binPath, `#!/usr/bin/env node\n${current}`);
       }
       Deno.chmodSync(binPath, 0o755);

--- a/packages/tufa/src/cli/command-definitions/messaging.ts
+++ b/packages/tufa/src/cli/command-definitions/messaging.ts
@@ -37,6 +37,9 @@ function registerExnSendSubCmd(
   dispatch: CommandDispatch,
   name: "exchange.send" | "exn.send",
 ): void {
+  // `exchange send` and `exn send` are CLI aliases over the same handler.
+  // Keeping the registration shared prevents their forwarding/topic options
+  // from drifting.
   root
     .command("send")
     .description("Send one signed EXN message to a resolved remote identifier")

--- a/packages/tufa/src/cli/command-definitions/witness.ts
+++ b/packages/tufa/src/cli/command-definitions/witness.ts
@@ -2,7 +2,12 @@
 import { Command } from "npm:commander@^10.0.1";
 import type { CommandDispatch } from "../command-types.ts";
 
-/** Register witness commands. */
+/**
+ * Register witness commands.
+ *
+ * `witness start` owns host provisioning, while `witness submit` owns
+ * controller-to-witness receipt convergence for an existing controller AID.
+ */
 export function registerWitnessCmds(
   program: Command,
   dispatch: CommandDispatch,

--- a/packages/tufa/src/cli/handlers.ts
+++ b/packages/tufa/src/cli/handlers.ts
@@ -12,6 +12,8 @@ import type { CommandHandler } from "./command-types.ts";
 
 /** Build the canonical command-dispatch map used by the Tufa CLI runtime. */
 export function createCmdHandlers(): Map<string, CommandHandler> {
+  // Lazy imports keep the runnable `tufa` package as the dispatch owner while
+  // still allowing reusable library CLI operations to live in `keri-ts/cli`.
   return new Map([
     ["init", lazyCommand(() => import("keri-ts/cli"), "initCommand")],
     ["incept", lazyCommand(() => import("keri-ts/cli"), "inceptCommand")],

--- a/packages/tufa/src/cli/mailbox.ts
+++ b/packages/tufa/src/cli/mailbox.ts
@@ -563,6 +563,13 @@ function mailboxConfigCandidates(
   return [...candidates];
 }
 
+/**
+ * Resolve explicit or config-provided mailbox startup material.
+ *
+ * Unlike witness startup, mailbox startup does not synthesize a new URL for a
+ * missing existing alias; operators must provide either config/CLI material or
+ * already accepted endpoint state.
+ */
 function resolveConfiguredStartup(
   args: MailboxStartArgs,
   config: Record<string, unknown> | null,
@@ -626,6 +633,7 @@ function resolveConfiguredStartup(
   return configured;
 }
 
+/** Resolve the final startup material, falling back to accepted endpoint state. */
 function resolveEffectiveStartupMaterial(
   hby: Habery,
   pre: string,
@@ -668,6 +676,7 @@ function validateMailboxHabitat(
   }
 }
 
+/** Return true when self location plus controller/mailbox roles are accepted. */
 function mailboxIdentityComplete(
   hby: Habery,
   pre: string,
@@ -692,6 +701,8 @@ function storedMailboxUrl(
   hby: Habery,
   pre: string,
 ): string | null {
+  // Treat multiple stored HTTP(S) URLs as an operator error. A mailbox host
+  // needs one canonical advertised origin for admin and OOBI URLs.
   const urls = fetchEndpointUrls(hby, pre);
   const candidates = [urls.https, urls.http]
     .filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
@@ -712,6 +723,8 @@ function* reconcileMailboxIdentity(
   hab: ReturnType<typeof requireHab>,
   startup: MailboxStartupMaterial,
 ): Operation<void> {
+  // Feed self-authored location and role replies through the normal runtime
+  // path instead of mutating `locs.` or `ends.` directly.
   const runtime = yield* createAgentRuntime(hby, { mode: "local" });
   const scheme = new URL(startup.url).protocol === "https:" ? "https" : "http";
   ingestKeriBytes(

--- a/packages/tufa/src/cli/witness.ts
+++ b/packages/tufa/src/cli/witness.ts
@@ -1,3 +1,11 @@
+/**
+ * Tufa witness operator commands.
+ *
+ * The witness role is a combined witness+mailbox host backed by one
+ * non-transferable local habitat. Startup reconciles self endpoint and role
+ * replies before serving, so later OOBI and receipt flows see durable state
+ * rather than process-local defaults.
+ */
 import type { Operation } from "effection";
 import { join } from "jsr:@std/path";
 import {
@@ -49,6 +57,7 @@ interface WitnessSubmitArgs extends WitnessBaseArgs {
   codeTime?: string;
 }
 
+/** Resolved startup material and its authority source for one witness host. */
 interface WitnessStartupMaterial {
   httpUrl: string;
   tcpUrl: string;
@@ -231,6 +240,7 @@ function parseWitnessStartArgs(
   return parsed;
 }
 
+/** Load an explicit witness config file without creating missing config state. */
 function* loadWitnessStartConfig(
   args: WitnessStartArgs,
 ): Operation<Configer | undefined> {
@@ -272,6 +282,7 @@ function* loadWitnessStartConfig(
   throw new ValidationError(`Config file '${args.configFile}' was not found.`);
 }
 
+/** Candidate config locations accepted for KLI-compatible operator workflows. */
 function witnessConfigCandidates(
   configFile: string,
   headDirPath?: string,
@@ -302,6 +313,15 @@ function witnessConfigCandidates(
   return [...candidates];
 }
 
+/**
+ * Resolve witness startup material in authority order.
+ *
+ * Precedence:
+ * - explicit CLI URL/TCP URL input
+ * - alias-scoped config section
+ * - already accepted local endpoint state
+ * - synthesized localhost defaults for first-run convenience
+ */
 function resolveWitnessStartupMaterial(
   hby: Habery,
   pre: string,
@@ -425,6 +445,8 @@ function storedWitnessStartupMaterial(
   hby: Habery,
   pre: string,
 ): WitnessStartupMaterial | null {
+  // Stored state is authoritative only when there is exactly one HTTP(S) URL
+  // and exactly one TCP URL; ambiguity would make advertised OOBIs unstable.
   const urls = fetchEndpointUrls(hby, pre);
   const httpEntries = [urls.https, urls.http]
     .filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
@@ -466,6 +488,7 @@ function witnessIdentityComplete(
     && roleEnabled(hby, pre, EndpointRoles.mailbox, pre);
 }
 
+/** Persist self location and role replies required before serving witness traffic. */
 function* reconcileWitnessIdentity(
   hby: Habery,
   hab: Hab,
@@ -549,6 +572,7 @@ function resolveWitnessAuths(
   return auths;
 }
 
+/** Normalize the advertised HTTP(S) witness URL while preserving path prefix. */
 function normalizeHttpUrl(url: string): string {
   const parsed = new URL(url);
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
@@ -558,6 +582,7 @@ function normalizeHttpUrl(url: string): string {
   return `${parsed.protocol}//${parsed.host}${pathname}${parsed.search}${parsed.hash}`;
 }
 
+/** Normalize the advertised TCP witness URL used by witness receipt transport. */
 function normalizeTcpUrl(url: string): string {
   const parsed = new URL(url);
   if (parsed.protocol !== "tcp:") {
@@ -596,6 +621,7 @@ function validateIsoDatetime(dt: string): string {
   return `${y}-${m}-${d}T${hh}:${mm}:${ss}.${micros}+00:00`;
 }
 
+/** Choose a bind address from explicit input or the advertised endpoint. */
 function resolveListenHost(
   explicit: string | undefined,
   advertisedUrl: string,

--- a/packages/tufa/src/http/protocol/context.ts
+++ b/packages/tufa/src/http/protocol/context.ts
@@ -1,3 +1,10 @@
+/**
+ * Request-context construction for Tufa protocol routing.
+ *
+ * The router is path-first: every endpoint classifier receives the same
+ * normalized path plus hosted-prefix projections, so mailbox admin, OOBI, and
+ * generic CESR ingress cannot disagree about which local AID a URL addresses.
+ */
 import { type AgentRuntime, type ProtocolHostPolicy, resolveHostedEndpointPath } from "keri-ts/runtime";
 import { parseOobiRouteRequest } from "./endpoints/oobi.ts";
 import type { ProtocolRequestContext } from "./types.ts";
@@ -10,6 +17,9 @@ export function buildProtocolRequestContext(
 ): ProtocolRequestContext {
   const url = new URL(req.url);
   const pathname = normalizeProtocolPath(url.pathname);
+  // Resolve the same normalized path against the three hosted path shapes used
+  // by the HTTP edge: plain hosted endpoints, mailbox admin endpoints, and
+  // generic root-relative CESR ingress.
   const hosted = runtime
     ? resolveHostedEndpointPath(
       runtime.hby,

--- a/packages/tufa/src/http/protocol/endpoints/generic-cesr-ingress.ts
+++ b/packages/tufa/src/http/protocol/endpoints/generic-cesr-ingress.ts
@@ -1,3 +1,10 @@
+/**
+ * Generic CESR POST/PUT ingress for the Tufa HTTP edge.
+ *
+ * Explicit routes are classified before this module runs. This handler owns
+ * the remaining raw CESR traffic and decides whether it belongs to local
+ * witness ingestion, mailbox SSE query streaming, or normal runtime ingress.
+ */
 import { concatBytes, Ilks, type SerderKERI } from "cesr-ts";
 import { run } from "effection";
 import {
@@ -17,6 +24,8 @@ const NONE_HOSTED_ROUTE: HostedRouteResolution = {
   endpoint: null,
   relativePath: null,
 };
+
+/** Upper bound for a direct `/logs` query response to wait for replay cues. */
 const DIRECT_QUERY_RESPONSE_WAIT_MS = 60_000;
 
 /** Classify generic POST/PUT CESR ingress after all explicit HTTP routes. */
@@ -62,6 +71,8 @@ export function classifyCesrIngressRoute(
     && serder.ilk !== Ilks.qry
     && serder.ilk !== Ilks.exn
   ) {
+    // Witness-hosted events are accepted locally by the witness processor, but
+    // witness `qry` and peer `exn` traffic still belongs to runtime routing.
     return { kind: "witnessLocalIngress", witnessHab };
   }
 
@@ -99,6 +110,7 @@ function querySseResponse(
   );
 }
 
+/** Collect immediate replay/reply wire cues into one direct CESR response. */
 function directQueryResponse(
   emissions: readonly CueEmission[],
 ): Response | null {
@@ -116,6 +128,7 @@ function directQueryResponse(
     : null;
 }
 
+/** Optionally wait for escrow replay to produce direct `/logs` response bytes. */
 function* deferredDirectQueryResponse(
   context: ProtocolRequestContext,
   serder: SerderKERI,
@@ -147,7 +160,7 @@ function* deferredDirectQueryResponse(
   return null;
 }
 
-/** Handle one generic POST/PUT CESR ingress request. */
+/** Handle one classified generic POST/PUT CESR ingress request. */
 export async function handleGenericCesrIngress(
   context: ProtocolRequestContext,
   hosted: HostedRouteResolution,

--- a/scripts/ci/run-keri-test-group.ts
+++ b/scripts/ci/run-keri-test-group.ts
@@ -1,8 +1,18 @@
 #!/usr/bin/env -S deno run -A
+/**
+ * Run annotated KERI test lanes for CI and local stage-gate parity.
+ *
+ * Ownership model:
+ * - test files declare membership with `@file-test-lane`
+ * - individual `Deno.test` registrations may override with `@test-lane`
+ * - this runner audits annotations first, then executes configured lanes or
+ *   lane groups with the concurrency policy declared below
+ */
 
 import { fromFileUrl } from "jsr:@std/path/from-file-url";
 import { relative } from "jsr:@std/path/relative";
 
+/** Execution policy for one lane of annotated KERI tests. */
 interface LaneConfig {
   description: string;
   allowAll?: boolean;
@@ -11,21 +21,25 @@ interface LaneConfig {
   maxJobs?: number;
 }
 
+/** Public alias that expands to one or more concrete lanes. */
 interface GroupDefinition {
   description: string;
   lanes: string[];
 }
 
+/** One discovered `Deno.test` registration and its resolved lane. */
 interface DiscoveredTest {
   name: string;
   lane: string;
 }
 
+/** Lane metadata discovered from a single test file. */
 interface FileLaneDiscovery {
   fileLane: string;
   tests: DiscoveredTest[];
 }
 
+/** Files that can run whole vs tests that must be split by filter. */
 interface LaneRunShape {
   fullFiles: string[];
   splitFiles: Array<{ file: string; tests: string[] }>;
@@ -218,6 +232,12 @@ async function walkTests(dir: URL, files: string[]): Promise<void> {
   }
 }
 
+/**
+ * Extract static `Deno.test` names.
+ *
+ * Dynamic unnamed registrations are allowed only when the file has no
+ * per-test lane overrides; in that case the file lane owns every registration.
+ */
 function extractTestNames(source: string): string[] {
   const names: string[] = [];
   const directPattern = /Deno\.test\(\s*(?:"([^"]+)"|'([^']+)')/gs;
@@ -245,6 +265,12 @@ function extractTestNames(source: string): string[] {
   return named;
 }
 
+/**
+ * Parse lane annotations and bind them to test registrations.
+ *
+ * Audit failure is deliberate: CI lanes are only trustworthy when every test
+ * has explicit ownership and every per-test override is consumed exactly once.
+ */
 function parseFileLaneDiscovery(
   file: string,
   source: string,
@@ -318,6 +344,7 @@ function parseFileLaneDiscovery(
   return { fileLane, tests };
 }
 
+/** Discover all test files and their audited lane assignments. */
 async function buildDiscoveredTests(): Promise<Map<string, FileLaneDiscovery>> {
   const discovered = new Map<string, FileLaneDiscovery>();
   for (const file of await collectTestFiles()) {
@@ -327,6 +354,12 @@ async function buildDiscoveredTests(): Promise<Map<string, FileLaneDiscovery>> {
   return discovered;
 }
 
+/**
+ * Build lane execution shapes from audited discovery.
+ *
+ * Whole-file runs preserve Deno's normal file-level behavior. Split runs are
+ * used only when a file intentionally contributes tests to multiple lanes.
+ */
 function buildLaneRunShapes(
   discovered: Map<string, FileLaneDiscovery>,
 ): Record<string, LaneRunShape> {
@@ -369,6 +402,7 @@ interface AuditResult {
   discoveredTests: number;
 }
 
+/** Verify lane ownership before any target-specific execution starts. */
 async function auditLaneAssignments(): Promise<AuditResult> {
   const discovered = await buildDiscoveredTests();
   let discoveredTests = 0;
@@ -381,6 +415,7 @@ async function auditLaneAssignments(): Promise<AuditResult> {
   };
 }
 
+/** Resolve a CLI target to concrete lane names or print usage on mismatch. */
 function resolveLaneNames(target: string): string[] {
   if (target in laneConfigs) {
     return [target];
@@ -425,6 +460,12 @@ function parsePositiveIntEnv(key: string): number | null {
   return parsed;
 }
 
+/**
+ * Resolve lane concurrency with explicit environment overrides first.
+ *
+ * `KERI_TEST_JOBS` is the runner-specific knob. `DENO_JOBS` remains supported
+ * for CI compatibility, and automatic selection is capped by lane policy.
+ */
 function resolveParallelJobs(config: LaneConfig): ParallelJobResolution {
   const available = Math.max(navigator.hardwareConcurrency || 1, 1);
   const keriJobs = parsePositiveIntEnv("KERI_TEST_JOBS");
@@ -456,6 +497,7 @@ function resolveParallelJobs(config: LaneConfig): ParallelJobResolution {
   };
 }
 
+/** Run one Deno test command and fail the runner with the child exit code. */
 async function runDenoTest(
   args: string[],
   label: string,
@@ -484,6 +526,7 @@ function baseTestArgs(config: LaneConfig): string[] {
   return args;
 }
 
+/** Execute one concrete lane according to its whole-file/split-file shape. */
 async function runLane(
   laneName: string,
   shapes: Record<string, LaneRunShape>,

--- a/scripts/smoke-test-keri-npm.sh
+++ b/scripts/smoke-test-keri-npm.sh
@@ -28,6 +28,9 @@ if [[ ! -f "${TARBALL_PATH}" ]]; then
 fi
 
 assert_tarball_export_targets() {
+  # Validate the packed artifact itself before Docker install. This catches
+  # manifest path drift even when Node would otherwise fail later with a less
+  # actionable module-resolution error.
   local manifest_json
   local target_paths
   manifest_json="$(tar -xOzf "${TARBALL_PATH}" package/package.json)"
@@ -104,6 +107,8 @@ fi
 
 SMOKE_NODE_IMAGE="${SMOKE_NODE_IMAGE:-node:alpine}"
 
+# Use a clean container install so the smoke test exercises the packed npm
+# artifact and optional local CESR tarball, not workspace symlinks or caches.
 echo "Running Docker smoke test with ${TARBALL_NAME} on ${SMOKE_NODE_IMAGE}"
 docker run --rm \
   "${DOCKER_ARGS[@]}" \

--- a/scripts/smoke-test-tufa-npm.sh
+++ b/scripts/smoke-test-tufa-npm.sh
@@ -36,6 +36,8 @@ if [[ ! -f "${SAMPLES_DIR}/${SAMPLE_STREAM_REL}" ]]; then
 fi
 
 assert_tarball_package_targets() {
+  # Validate module/export/bin targets from the packed tarball before install.
+  # This is the fastest failure mode for DNT output or package.json drift.
   local manifest_json
   local target_paths
   manifest_json="$(tar -xOzf "${TARBALL_PATH}" package/package.json)"
@@ -131,6 +133,8 @@ fi
 
 SMOKE_NODE_IMAGE="${SMOKE_NODE_IMAGE:-node:alpine}"
 
+# Use a clean global install because Tufa's release contract is primarily the
+# executable. Workspace imports are optional local tarballs, never symlinks.
 echo "Running Docker smoke test with ${TARBALL_NAME} on ${SMOKE_NODE_IMAGE}"
 docker run --rm \
   "${DOCKER_ARGS[@]}" \


### PR DESCRIPTION
## Summary
- Add maintainer-oriented documentation for delegation workflow, notification sidecars, forwarding/mailbox ingress, witness startup, and Tufa CLI host behavior.
- Document KERI/KERIpy parity seams in KEL processing, source-seal repair, protocol event factories, and CESR parser helper policy.
- Document npm build normalization, smoke-test artifact assertions, CI lane ownership, and delegation interop scenario helpers.

## Validation
- deno task fmt:check
- deno task check

## Notes
- Documentation-only change; no behavior, API, protocol, release, or test expectation changes intended.
- Per request, this PR is left open for maintainer review and will not be merged by Codex.