### PR TITLE
tests: respect temp=true for fast tests

### DIFF
--- a/packages/keri/src/app/habbing.ts
+++ b/packages/keri/src/app/habbing.ts
@@ -588,6 +588,7 @@ export class Hab {
       algo,
       salt,
       tier,
+      temp: this.ks.temp,
     });
 
     if (!transferable && verfers.length === 1) {

--- a/packages/keri/src/app/keeping.ts
+++ b/packages/keri/src/app/keeping.ts
@@ -856,9 +856,9 @@ export class Manager {
         ridx: lot.ridx,
         kidx: lot.kidx + offset,
         transferable: verfer.transferable,
-        // Persisted keeper parameters do not retain temp/stretch mode, so
-        // derived signing must use the normal persisted-sequence behavior.
-        temp: false,
+        // Temp keepers create temp-derived keys, so path re-derivation must
+        // mirror the active keeper mode. Durable keepers remain production-cost.
+        temp: this.ks.temp,
       })[0];
 
       if (!signer || signer.verfer.qb64 !== pub) {
@@ -1265,8 +1265,8 @@ export class Manager {
    *
    * Maintainer warning:
    * - derived salty signing depends only on persisted keeper parameters
-   * - temporary stretch mode (`temp=true`) is not part of `PrePrm`, so this path
-   *   is intended for normal persisted key sequences rather than temp-only tests
+   * - temporary stretch mode (`temp=true`) is taken from the active keeper so
+   *   path signing can rederive keys created by temp test stores
    *
    * Signature-index semantics adapted from KERIpy:
    * - explicit `pubs` / `verfers` keep the usual coherent-list behavior:

--- a/packages/keri/test/unit/app/habbing.test.ts
+++ b/packages/keri/test/unit/app/habbing.test.ts
@@ -50,6 +50,36 @@ function makeEmbeddedExchangeMessage(
   return { serder, attachments };
 }
 
+Deno.test("Hab.make propagates temporary keeper mode into key inception", async () => {
+  await run(function*() {
+    const hby = yield* createHabery({
+      name: `habery-temp-incept-${crypto.randomUUID()}`,
+      temp: true,
+    });
+    type InceptArgs = NonNullable<Parameters<typeof hby.mgr.incept>[0]>;
+    const originalIncept = hby.mgr.incept.bind(hby.mgr);
+    const seenTemps: Array<boolean | undefined> = [];
+    hby.mgr.incept = ((args: InceptArgs = {}) => {
+      seenTemps.push(args.temp);
+      return originalIncept(args);
+    }) as typeof hby.mgr.incept;
+    try {
+      hby.makeHab("alice", undefined, {
+        transferable: true,
+        icount: 1,
+        isith: "1",
+        ncount: 1,
+        nsith: "1",
+        toad: 0,
+      });
+
+      assertEquals(seenTemps, [true]);
+    } finally {
+      yield* hby.close(true);
+    }
+  });
+});
+
 Deno.test("Hab.rotate reuses one Habery for success and rollback coverage", async () => {
   await run(function*() {
     const hby = yield* createHabery({

--- a/packages/keri/test/unit/core/eventing.test.ts
+++ b/packages/keri/test/unit/core/eventing.test.ts
@@ -291,6 +291,7 @@ function rotationPrm(
   hby: {
     mgr: {
       ks: {
+        temp: boolean;
         getPrms(pre: string): {
           pidx: number;
           stem: string;
@@ -308,6 +309,7 @@ function rotationPrm(
     salt: prm.salt,
     tier: prm.tier || Tiers.low,
     rootStem: prm.stem || prm.pidx.toString(16),
+    temp: hby.mgr.ks.temp,
   };
 }
 
@@ -322,7 +324,7 @@ function deriveRotationSigner(
     `${prm.rootStem}${pathSuffix}`,
     true,
     prm.tier,
-    false,
+    prm.temp,
   );
 }
 

--- a/packages/keri/test/unit/db/keeping.test.ts
+++ b/packages/keri/test/unit/db/keeping.test.ts
@@ -169,7 +169,7 @@ Deno.test("app/keeping - Manager.sign derives current salty signers from pre and
         ncount: 2,
         stem: "phlegm",
         transferable: true,
-        temp: false,
+        temp: true,
       });
       const pre = verfers[0].qb64;
       const sit = keeper.getSits(pre)!;
@@ -210,7 +210,7 @@ Deno.test("app/keeping - Manager.sign derives next-lot salty signers from explic
         ncount: 2,
         stem: "phlegm",
         transferable: true,
-        temp: false,
+        temp: true,
       });
       const pre = verfers[0].qb64;
       const sit = keeper.getSits(pre)!;
@@ -251,7 +251,7 @@ Deno.test("app/keeping - Manager.sign derived-path indices select and order salt
         ncount: 1,
         stem: "phlegm",
         transferable: true,
-        temp: false,
+        temp: true,
       });
       const pre = verfers[0].qb64;
       const sit = keeper.getSits(pre)!;
@@ -315,7 +315,7 @@ Deno.test("app/keeping - Manager.sign derived-path ondices match explicit pubs s
         ncount: 1,
         stem: "phlegm",
         transferable: true,
-        temp: false,
+        temp: true,
       });
       const pre = verfers[0].qb64;
       const sit = keeper.getSits(pre)!;
@@ -417,13 +417,13 @@ Deno.test("app/keeping - Manager.sign derives historical salty lots from pubs st
         ncount: 1,
         stem: "phlegm",
         transferable: true,
-        temp: false,
+        temp: true,
       });
       const pre = verfers[0].qb64;
       const ser = new TextEncoder().encode("derived-history");
 
-      manager.rotate({ pre, ncount: 1, transferable: true, temp: false });
-      manager.rotate({ pre, ncount: 1, transferable: true, temp: false });
+      manager.rotate({ pre, ncount: 1, transferable: true, temp: true });
+      manager.rotate({ pre, ncount: 1, transferable: true, temp: true });
 
       assertEquals(keeper.pris.get(verfers[0].qb64), null);
 
@@ -461,7 +461,7 @@ Deno.test("app/keeping - Manager.sign preserves branch precedence for pubs then 
         ncount: 1,
         stem: "phlegm",
         transferable: true,
-        temp: false,
+        temp: true,
       });
       const pre = verfers[0].qb64;
       const sit = keeper.getSits(pre)!;
@@ -562,8 +562,8 @@ Deno.test("app/keeping - Manager.sign derived-path fails when historical pubs ar
       const pre = verfers[0].qb64;
       const ser = new TextEncoder().encode("derived-missing");
 
-      manager.rotate({ pre, ncount: 1, transferable: true, temp: false });
-      manager.rotate({ pre, ncount: 1, transferable: true, temp: false });
+      manager.rotate({ pre, ncount: 1, transferable: true, temp: true });
+      manager.rotate({ pre, ncount: 1, transferable: true, temp: true });
 
       keeper.pubs.rem(keeperPubsKey(pre, 0));
       assertThrows(

--- a/scripts/ci/run-keri-test-group.ts
+++ b/scripts/ci/run-keri-test-group.ts
@@ -9,6 +9,7 @@
  *   lane groups with the concurrency policy declared below
  */
 
+import { dirname } from "jsr:@std/path/dirname";
 import { fromFileUrl } from "jsr:@std/path/from-file-url";
 import { relative } from "jsr:@std/path/relative";
 
@@ -43,6 +44,34 @@ interface FileLaneDiscovery {
 interface LaneRunShape {
   fullFiles: string[];
   splitFiles: Array<{ file: string; tests: string[] }>;
+}
+
+/** One child `deno test` command timing for CI and local comparisons. */
+interface TestCommandTiming {
+  lane: string;
+  label: string;
+  args: string[];
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  success: boolean;
+}
+
+interface TimingOutput {
+  target: string;
+  generatedAt: string;
+  totalDurationMs: number;
+  audit: AuditResult;
+  commands: TestCommandTiming[];
+}
+
+class DenoTestFailure extends Error {
+  readonly code: number;
+
+  constructor(code: number, label: string) {
+    super(`${label} failed with exit code ${code}.`);
+    this.code = code;
+  }
 }
 
 const packageDir = new URL("../../packages/keri/", import.meta.url);
@@ -497,13 +526,105 @@ function resolveParallelJobs(config: LaneConfig): ParallelJobResolution {
   };
 }
 
-/** Run one Deno test command and fail the runner with the child exit code. */
+function formatDuration(durationMs: number): string {
+  if (durationMs < 1000) {
+    return `${durationMs}ms`;
+  }
+
+  const totalSeconds = durationMs / 1000;
+  if (totalSeconds < 60) {
+    return `${totalSeconds.toFixed(1)}s`;
+  }
+
+  const roundedSeconds = Math.round(totalSeconds);
+  const minutes = Math.floor(roundedSeconds / 60);
+  const seconds = roundedSeconds % 60;
+  return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[\\/^$.*+?()[\]{}|]/g, "\\$&");
+}
+
+function splitTestFilter(testNames: string[]): string {
+  return `/^(?:${testNames.map(escapeRegex).join("|")})$/`;
+}
+
+function sortedTimings(timings: TestCommandTiming[]): TestCommandTiming[] {
+  return [...timings].sort((left, right) => right.durationMs - left.durationMs);
+}
+
+function timingMarkdown(output: TimingOutput): string {
+  const lines = [
+    `## KERI test timings: ${output.target}`,
+    "",
+    `Total child-command time: ${formatDuration(output.totalDurationMs)}`,
+    "",
+    "| Duration | Lane | Command |",
+    "|---:|---|---|",
+  ];
+
+  for (const timing of sortedTimings(output.commands)) {
+    lines.push(
+      `| ${formatDuration(timing.durationMs)} | ${timing.lane} | ${timing.label.replaceAll("|", "\\|")} |`,
+    );
+  }
+
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function timingJsonPath(target: string): string | null {
+  const explicit = Deno.env.get("KERI_TEST_TIMINGS_JSON")?.trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  if (Deno.env.get("GITHUB_ACTIONS") === "true") {
+    const dir = Deno.env.get("KERI_TEST_TIMINGS_DIR")?.trim()
+      || ".test-timings";
+    const job = Deno.env.get("GITHUB_JOB")?.trim() || "keri-tests";
+    return `${dir}/${job}-${target}.json`;
+  }
+
+  return null;
+}
+
+async function emitTimingOutputs(output: TimingOutput): Promise<void> {
+  if (output.commands.length === 0) {
+    return;
+  }
+
+  const markdown = timingMarkdown(output);
+  console.log(markdown.trimEnd());
+
+  const summaryPath = Deno.env.get("GITHUB_STEP_SUMMARY")?.trim();
+  if (summaryPath) {
+    await Deno.writeTextFile(summaryPath, markdown, { append: true });
+  }
+
+  const jsonPath = timingJsonPath(output.target);
+  if (jsonPath) {
+    await Deno.mkdir(dirname(jsonPath), { recursive: true });
+    await Deno.writeTextFile(
+      jsonPath,
+      `${JSON.stringify(output, null, 2)}\n`,
+    );
+    console.log(`==> Wrote KERI test timings to ${jsonPath}`);
+  }
+}
+
+/** Run one Deno test command and record its child-process duration. */
 async function runDenoTest(
   args: string[],
   label: string,
+  laneName: string,
+  timings: TestCommandTiming[],
   env?: Record<string, string>,
 ): Promise<void> {
   console.log(`==> ${label}`);
+  const startedAt = new Date();
+  const start = performance.now();
   const child = new Deno.Command("deno", {
     args,
     cwd: fromFileUrl(packageDir),
@@ -513,8 +634,20 @@ async function runDenoTest(
     stderr: "inherit",
   }).spawn();
   const status = await child.status;
+  const completedAt = new Date();
+  const durationMs = Math.round(performance.now() - start);
+  timings.push({
+    lane: laneName,
+    label,
+    args,
+    startedAt: startedAt.toISOString(),
+    completedAt: completedAt.toISOString(),
+    durationMs,
+    success: status.success,
+  });
+  console.log(`==> ${label} completed in ${formatDuration(durationMs)}`);
   if (!status.success) {
-    Deno.exit(status.code);
+    throw new DenoTestFailure(status.code, label);
   }
 }
 
@@ -530,6 +663,7 @@ function baseTestArgs(config: LaneConfig): string[] {
 async function runLane(
   laneName: string,
   shapes: Record<string, LaneRunShape>,
+  timings: TestCommandTiming[],
 ): Promise<void> {
   const config = laneConfigs[laneName];
   const shape = shapes[laneName];
@@ -548,6 +682,8 @@ async function runLane(
       await runDenoTest(
         [...baseTestArgs(config), "--parallel", ...batch],
         `${laneName} full files batch ${index + 1}`,
+        laneName,
+        timings,
         env,
       );
     }
@@ -556,22 +692,24 @@ async function runLane(
       await runDenoTest(
         [...baseTestArgs(config), file],
         `${laneName} full file ${file}`,
+        laneName,
+        timings,
       );
     }
   }
 
   for (const splitFile of shape.splitFiles) {
-    for (const testName of splitFile.tests) {
-      await runDenoTest(
-        [
-          ...baseTestArgs(config),
-          "--filter",
-          testName,
-          splitFile.file,
-        ],
-        `${laneName} split test ${splitFile.file} :: ${testName}`,
-      );
-    }
+    await runDenoTest(
+      [
+        ...baseTestArgs(config),
+        "--filter",
+        splitTestFilter(splitFile.tests),
+        splitFile.file,
+      ],
+      `${laneName} split file ${splitFile.file} (${splitFile.tests.length} tests)`,
+      laneName,
+      timings,
+    );
   }
 }
 
@@ -581,6 +719,7 @@ async function main(): Promise<void> {
     usage();
   }
 
+  const timings: TestCommandTiming[] = [];
   const audit = await auditLaneAssignments();
   console.log(
     `==> Lane audit passed: ${audit.discoveredFiles} files, ${audit.discoveredTests} tests annotated`,
@@ -592,8 +731,32 @@ async function main(): Promise<void> {
 
   const discovered = await buildDiscoveredTests();
   const shapes = buildLaneRunShapes(discovered);
-  for (const laneName of resolveLaneNames(target)) {
-    await runLane(laneName, shapes);
+  let exitCode = 0;
+  try {
+    for (const laneName of resolveLaneNames(target)) {
+      await runLane(laneName, shapes, timings);
+    }
+  } catch (error) {
+    if (error instanceof DenoTestFailure) {
+      exitCode = error.code;
+    } else {
+      throw error;
+    }
+  } finally {
+    await emitTimingOutputs({
+      target,
+      generatedAt: new Date().toISOString(),
+      totalDurationMs: timings.reduce(
+        (total, timing) => total + timing.durationMs,
+        0,
+      ),
+      audit,
+      commands: timings,
+    });
+  }
+
+  if (exitCode !== 0) {
+    Deno.exit(exitCode);
   }
 }
 


### PR DESCRIPTION
Signing times were eating up a lot of CPU cycles and wall clock time. Respecting temp = true really speeds things up.