### PR TITLE
release: prepare 0.7.0 release train

### DIFF
--- a/.changeset/cesr-build-script-infra.md
+++ b/.changeset/cesr-build-script-infra.md
@@ -1,6 +1,0 @@
----
-"cesr-ts": patch
----
-
-Move CESR build, version, and table-generation support into checked shared
-scripts instead of inline release logic.

--- a/.changeset/cesr-package-cli.md
+++ b/.changeset/cesr-package-cli.md
@@ -1,8 +1,0 @@
----
-"cesr-ts": minor
----
-
-BREAKING CLI CHANGE: replace the CESR package's executable surface with the
-package-level `tephra` CLI. The annotation workflow is now `tephra annotate`,
-validation is available as `tephra validate`, and parser benchmarking is
-available as `tephra bench`.

--- a/.changeset/enforce-changeset-discipline.md
+++ b/.changeset/enforce-changeset-discipline.md
@@ -1,5 +1,0 @@
----
----
-
-No release impact: add CI, Lefthook, and repo-local agent instructions that
-require Changesets release intent before PR merge.

--- a/.changeset/keri-build-script-infra.md
+++ b/.changeset/keri-build-script-infra.md
@@ -1,6 +1,0 @@
----
-"keri-ts": patch
----
-
-Move KERI npm build, LMDB setup discovery, version generation, and
-installed-artifact checks into checked shared scripts.

--- a/.changeset/keri-npm-artifact-smoke.md
+++ b/.changeset/keri-npm-artifact-smoke.md
@@ -1,6 +1,0 @@
----
-"keri-ts": patch
----
-
-Harden the `keri-ts` npm artifact by deriving DNT export targets from the
-generated package output and smoke-checking packed and installed package paths.

--- a/.changeset/keri-temp-crypto-test-speed.md
+++ b/.changeset/keri-temp-crypto-test-speed.md
@@ -1,6 +1,0 @@
----
-"keri-ts": patch
----
-
-Honor temp keeper derivation during habitat inception and add KERI test lane
-timing output for easier test-speed regression tracking.

--- a/.changeset/runtime-services-test-speed.md
+++ b/.changeset/runtime-services-test-speed.md
@@ -1,8 +1,0 @@
----
-"keri-ts": patch
----
-
-Add injectable runtime clock, HTTP, and mailbox polling seams so runtime tests
-can exercise protocol behavior without repeated real sockets and sleeps. Convert
-mailbox poller, mailbox admin, and witness runtime coverage to cheaper
-fixtures while preserving representative live transport tests.

--- a/.changeset/tufa-build-script-infra.md
+++ b/.changeset/tufa-build-script-infra.md
@@ -1,6 +1,0 @@
----
-"@keri-ts/tufa": patch
----
-
-Move Tufa npm build, host health wait, version generation, and smoke-test
-helpers into checked shared scripts.

--- a/.changeset/tufa-npm-bin-metadata.md
+++ b/.changeset/tufa-npm-bin-metadata.md
@@ -1,6 +1,0 @@
----
-"@keri-ts/tufa": patch
----
-
-Normalize the Tufa npm `bin.tufa` entry to a bare relative path so npm publish
-does not rewrite package metadata.

--- a/.changeset/tufa-npm-bin-paths.md
+++ b/.changeset/tufa-npm-bin-paths.md
@@ -1,6 +1,0 @@
----
-"@keri-ts/tufa": patch
----
-
-Harden Tufa npm packaging by deriving module and CLI bin paths from DNT output
-and validating those targets in tarball and install smoke tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -205,17 +205,17 @@
     },
     "packages/cesr": {
       "name": "cesr-ts",
-      "version": "0.5.0",
+      "version": "0.7.0",
       "license": "Apache-2.0"
     },
     "packages/keri": {
       "name": "keri-ts",
-      "version": "0.5.0",
+      "version": "0.7.0",
       "license": "Apache-2.0"
     },
     "packages/tufa": {
       "name": "@keri-ts/tufa",
-      "version": "0.5.0",
+      "version": "0.7.0",
       "license": "Apache-2.0"
     }
   }

--- a/packages/cesr/CHANGELOG.md
+++ b/packages/cesr/CHANGELOG.md
@@ -1,5 +1,19 @@
 # cesr-ts
 
+## 0.7.0
+
+### Minor Changes
+
+- 7c5fa42: BREAKING CLI CHANGE: replace the CESR package's executable surface with the
+  package-level `tephra` CLI. The annotation workflow is now `tephra annotate`,
+  validation is available as `tephra validate`, and parser benchmarking is
+  available as `tephra bench`.
+
+### Patch Changes
+
+- 87940ec: Move CESR build, version, and table-generation support into checked shared
+  scripts instead of inline release logic.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/cesr/deno.json
+++ b/packages/cesr/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@keri-ts/cesr",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/cesr/package.json
+++ b/packages/cesr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesr-ts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Monorepo metadata for cesr-ts versioning and release tooling",
   "license": "Apache-2.0",

--- a/packages/cesr/src/version.ts
+++ b/packages/cesr/src/version.ts
@@ -6,7 +6,7 @@
  * `src/version.ts` files by hand; edit this template instead.
  */
 /** Package semantic version copied from the owning package manifest. */
-export const PACKAGE_VERSION = "0.6.0";
+export const PACKAGE_VERSION = "0.7.0";
 /** Optional build metadata stamp injected by release/CI workflows. */
 export const BUILD_METADATA = "";
 /** User-facing version string with build metadata appended when present. */

--- a/packages/keri/CHANGELOG.md
+++ b/packages/keri/CHANGELOG.md
@@ -1,5 +1,24 @@
 # keri-ts
 
+## 0.7.0
+
+### Minor Changes
+
+- Align KERI and Tufa with the 0.7.0 release train after the CESR CLI break so generated npm artifacts depend on the 0.7.0 package line.
+
+### Patch Changes
+
+- 87940ec: Move KERI npm build, LMDB setup discovery, version generation, and
+  installed-artifact checks into checked shared scripts.
+- 87940ec: Harden the `keri-ts` npm artifact by deriving DNT export targets from the
+  generated package output and smoke-checking packed and installed package paths.
+- 87940ec: Honor temp keeper derivation during habitat inception and add KERI test lane
+  timing output for easier test-speed regression tracking.
+- 1c4fb92: Add injectable runtime clock, HTTP, and mailbox polling seams so runtime tests
+  can exercise protocol behavior without repeated real sockets and sleeps. Convert
+  mailbox poller, mailbox admin, and witness runtime coverage to cheaper
+  fixtures while preserving representative live transport tests.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/keri/deno.json
+++ b/packages/keri/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "keri-ts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "exports": {
     ".": "./mod.ts",
     "./cli": "./cli.ts",

--- a/packages/keri/package.json
+++ b/packages/keri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keri-ts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "KERI TypeScript protocol and runtime library",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/keri/src/app/version.ts
+++ b/packages/keri/src/app/version.ts
@@ -6,7 +6,7 @@
  * `src/version.ts` files by hand; edit this template instead.
  */
 /** Package semantic version copied from the owning package manifest. */
-export const PACKAGE_VERSION = "0.6.0";
+export const PACKAGE_VERSION = "0.7.0";
 /** Optional build metadata stamp injected by release/CI workflows. */
 export const BUILD_METADATA = "";
 /** User-facing version string with build metadata appended when present. */

--- a/packages/tufa/CHANGELOG.md
+++ b/packages/tufa/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @keri-ts/tufa
 
+## 0.7.0
+
+### Minor Changes
+
+- Align KERI and Tufa with the 0.7.0 release train after the CESR CLI break so generated npm artifacts depend on the 0.7.0 package line.
+
+### Patch Changes
+
+- 87940ec: Move Tufa npm build, host health wait, version generation, and smoke-test
+  helpers into checked shared scripts.
+- 87940ec: Normalize the Tufa npm `bin.tufa` entry to a bare relative path so npm publish
+  does not rewrite package metadata.
+- 87940ec: Harden Tufa npm packaging by deriving module and CLI bin paths from DNT output
+  and validating those targets in tarball and install smoke tests.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/tufa/deno.json
+++ b/packages/tufa/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "tufa",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/tufa/package.json
+++ b/packages/tufa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keri-ts/tufa",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Trust Utilities for Agents CLI application package",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/tufa/src/version.ts
+++ b/packages/tufa/src/version.ts
@@ -6,7 +6,7 @@
  * `src/version.ts` files by hand; edit this template instead.
  */
 /** Package semantic version copied from the owning package manifest. */
-export const PACKAGE_VERSION = "0.6.0";
+export const PACKAGE_VERSION = "0.7.0";
 /** Optional build metadata stamp injected by release/CI workflows. */
 export const BUILD_METADATA = "";
 /** User-facing version string with build metadata appended when present. */


### PR DESCRIPTION
## Summary

Prepare the 0.7.0 release train for:

- `cesr-ts`
- `keri-ts`
- `@keri-ts/tufa`

This is a release-version branch generated through Changesets. It consumes the pending changesets, aligns all three package manifests to `0.7.0`, regenerates package-local `deno.json` versions and runtime version modules, updates changelogs, and refreshes the stale workspace versions in `package-lock.json`.

Publishing remains tag-triggered through the existing GitHub Actions release workflows; this PR does not publish anything.

## Release Management Notes

After this PR is merged to `master`, release from CI by pushing tags in dependency order:

1. `cesr-v0.7.0`
2. wait until `cesr-ts@0.7.0` is visible on npm
3. `keri-v0.7.0`
4. wait until `keri-ts@0.7.0` is visible on npm
5. `tufa-v0.7.0`

The package workflows enforce tag/package version alignment before publishing. The Tufa workflow also checks that its exact `cesr-ts` and `keri-ts` dependency versions are already published before `npm publish`.

## Validation

Passed locally:

- `deno task version:check`
- `deno task changeset:check` (skips generated `changeset-release/*` branches as intended)
- `deno task npm:build:all`
- packed local artifacts:
  - `packages/cesr/npm/cesr-ts-0.7.0.tgz`
  - `packages/keri/npm/keri-ts-0.7.0.tgz`
  - `packages/tufa/npm/keri-ts-tufa-0.7.0.tgz`
- Docker smoke tests using those local tarballs as a set:
  - `bash scripts/smoke-test-tephra-npm.sh packages/cesr/npm/cesr-ts-0.7.0.tgz`
  - `bash scripts/smoke-test-keri-npm.sh packages/keri/npm/keri-ts-0.7.0.tgz packages/cesr/npm/cesr-ts-0.7.0.tgz`
  - `bash scripts/smoke-test-tufa-npm.sh packages/tufa/npm/keri-ts-tufa-0.7.0.tgz packages/cesr/npm/cesr-ts-0.7.0.tgz packages/keri/npm/keri-ts-0.7.0.tgz`

Local caveats:

- `npm trust list cesr-ts`, `npm trust list keri-ts`, and `npm trust list @keri-ts/tufa` were attempted but npm returned `EOTP`; trusted publisher verification needs an authenticated npm CLI session/OTP.
- `deno task quality` initially found the local pyenv `kli`, which is broken (`ModuleNotFoundError: No module named 'keri.app.cli.kli'`). The failed interop lane and the remaining interop lane passed when rerun with `/Users/kbull/code/keri/kentbull/core/python/keripy/venv/bin` first in `PATH`.
- A later full `deno task quality` rerun with the working KERIpy venv got through lint/docs/type checks, Tufa tests, and most KERI lanes, then failed when the native `lmdb` addon started returning `No space left on device` on new LMDB environments. A direct scratch `node -e 'require("lmdb").open(...)'` fails the same way outside repo code, so this appears to be local LMDB/OS IPC state. CI should be treated as the authoritative full quality gate for this PR.
