### PR TITLE
ci: unset LD_LIBRARY_PATH in npm smoke checks

### DIFF
--- a/.changeset/release-smoke-ld-library-path.md
+++ b/.changeset/release-smoke-ld-library-path.md
@@ -1,0 +1,5 @@
+---
+---
+
+No release impact: prevent Linux release smoke scripts from inheriting
+`LD_LIBRARY_PATH` into Deno's tarball assertion subprocess.

--- a/scripts/smoke-test-keri-npm.sh
+++ b/scripts/smoke-test-keri-npm.sh
@@ -27,7 +27,9 @@ if [[ ! -f "${TARBALL_PATH}" ]]; then
   exit 1
 fi
 
-deno run --allow-run=tar --allow-read "${ROOT_DIR}/scripts/npm/assert-tarball-targets.ts" "${TARBALL_PATH}"
+# setup-python exports LD_LIBRARY_PATH on Linux release runners; Deno rejects
+# spawning tar with that inherited environment unless the variable is removed.
+env -u LD_LIBRARY_PATH deno run --allow-run=tar --allow-read "${ROOT_DIR}/scripts/npm/assert-tarball-targets.ts" "${TARBALL_PATH}"
 
 TARBALL_DIR="$(cd "$(dirname "${TARBALL_PATH}")" && pwd)"
 TARBALL_NAME="$(basename "${TARBALL_PATH}")"

--- a/scripts/smoke-test-tephra-npm.sh
+++ b/scripts/smoke-test-tephra-npm.sh
@@ -29,7 +29,9 @@ if [[ ! -f "${SAMPLES_DIR}/${SAMPLE_STREAM_REL}" ]]; then
   exit 1
 fi
 
-deno run --allow-run=tar --allow-read "${ROOT_DIR}/scripts/npm/assert-tarball-targets.ts" "${TARBALL_PATH}" --include-bin
+# setup-python exports LD_LIBRARY_PATH on Linux release runners; Deno rejects
+# spawning tar with that inherited environment unless the variable is removed.
+env -u LD_LIBRARY_PATH deno run --allow-run=tar --allow-read "${ROOT_DIR}/scripts/npm/assert-tarball-targets.ts" "${TARBALL_PATH}" --include-bin
 
 TARBALL_DIR="$(cd "$(dirname "${TARBALL_PATH}")" && pwd)"
 TARBALL_NAME="$(basename "${TARBALL_PATH}")"

--- a/scripts/smoke-test-tufa-npm.sh
+++ b/scripts/smoke-test-tufa-npm.sh
@@ -34,7 +34,9 @@ if [[ ! -f "${SAMPLES_DIR}/${SAMPLE_STREAM_REL}" ]]; then
   exit 1
 fi
 
-deno run --allow-run=tar --allow-read "${ROOT_DIR}/scripts/npm/assert-tarball-targets.ts" "${TARBALL_PATH}" --include-bin
+# setup-python exports LD_LIBRARY_PATH on Linux release runners; Deno rejects
+# spawning tar with that inherited environment unless the variable is removed.
+env -u LD_LIBRARY_PATH deno run --allow-run=tar --allow-read "${ROOT_DIR}/scripts/npm/assert-tarball-targets.ts" "${TARBALL_PATH}" --include-bin
 
 TARBALL_DIR="$(cd "$(dirname "${TARBALL_PATH}")" && pwd)"
 TARBALL_NAME="$(basename "${TARBALL_PATH}")"


### PR DESCRIPTION
## Summary

Fix the npm smoke scripts so Deno's tarball assertion subprocess does not inherit `LD_LIBRARY_PATH` from GitHub Actions `setup-python`.

The `keri-v0.7.0` release workflow passed quality/build/pack, then failed before publish in `scripts/smoke-test-keri-npm.sh` with:

> Requires --allow-run permissions to spawn subprocess with LD_LIBRARY_PATH environment variable. Alternatively, spawn with the environment variable unset.

The scripts now run only the tarball assertion command with `LD_LIBRARY_PATH` unset. Docker smoke behavior is unchanged.

## Validation

- `bash -n scripts/smoke-test-keri-npm.sh scripts/smoke-test-tephra-npm.sh scripts/smoke-test-tufa-npm.sh`
- `LD_LIBRARY_PATH=/tmp env -u LD_LIBRARY_PATH deno run --allow-run=tar --allow-read scripts/npm/assert-tarball-targets.ts packages/keri/npm/keri-ts-0.7.0.tgz`
- `git diff --check`
- `deno task changeset:check` from a clean worktree

## Release Note

No package release impact. This is a CI release-path fix needed before retrying the `keri-ts@0.7.0` publish.
