### PR TITLE
ci: unset LD_LIBRARY_PATH for KERI release quality

### DIFF
--- a/.changeset/release-quality-ld-library-path.md
+++ b/.changeset/release-quality-ld-library-path.md
@@ -1,0 +1,5 @@
+---
+---
+
+No release impact: keep Python's `LD_LIBRARY_PATH` out of KERI release Deno
+quality and build steps.

--- a/.github/workflows/keri-ts-npm-release.yml
+++ b/.github/workflows/keri-ts-npm-release.yml
@@ -153,7 +153,9 @@ jobs:
       - name: test quality gate
         # Release packaging is only meaningful if the package still passes the
         # KERI runtime test surface right before build.
-        run: deno task test:quality
+        run: |
+          unset LD_LIBRARY_PATH
+          deno task test:quality
 
       - name: build npm package
         # CI metadata is opt-in. Release/build jobs explicitly stamp the runtime
@@ -161,6 +163,7 @@ jobs:
         env:
           BUILD_METADATA: build.${{ github.run_number }}.${{ github.sha }}
         run: |
+          unset LD_LIBRARY_PATH
           deno task version:generate:ci
           cd packages/keri
           deno task build:npm


### PR DESCRIPTION
## Summary

Keep `setup-python`'s `LD_LIBRARY_PATH` out of the KERI release Deno quality/build steps.

After PR #51 fixed the smoke script boundary, the retried `keri-v0.7.0` release failed twice in `deno task test:quality` with an LMDB branch iteration error in `mailbox-runtime.test.ts`. The same code passed PR stage gate, and the release job environment showed `LD_LIBRARY_PATH` inherited from `setup-python`.

This unsets `LD_LIBRARY_PATH` before the release Deno quality gate and npm build. Python/KERIpy setup still runs with the normal `setup-python` environment before these steps.

## Validation

- `git diff --check`
- `deno task changeset:check`

## Release Note

No package release impact. This is a KERI release workflow fix needed before retrying `keri-ts@0.7.0` publish.
