### PR TITLE
Stabilize Tufa agent readiness release test

### DIFF
--- a/.changeset/crisp-books-dance.md
+++ b/.changeset/crisp-books-dance.md
@@ -1,0 +1,4 @@
+---
+---
+
+No package release. Stabilizes the Tufa agent readiness integration test used by the release gate.

--- a/packages/tufa/test/integration/agent-cli.test.ts
+++ b/packages/tufa/test/integration/agent-cli.test.ts
@@ -21,9 +21,21 @@ async function startTufaAgent(
   port: number,
 ): Promise<SpawnedChild> {
   const child = spawnTufa(args);
+  const ready = waitForHealth(port, 180).then(() => ({ kind: "ready" as const }));
+  const exited = child.status.then((status) => ({
+    kind: "exited" as const,
+    status,
+  }));
 
   try {
-    await waitForHealth(port);
+    const result = await Promise.race([ready, exited]);
+    if (result.kind === "exited") {
+      throw new Error(
+        `Process exited before health check passed: code=${result.status.code}, signal=${
+          result.status.signal ?? "none"
+        }`,
+      );
+    }
     return child;
   } catch (error) {
     const details = await stopChild(child);

--- a/packages/tufa/test/test-helpers.ts
+++ b/packages/tufa/test/test-helpers.ts
@@ -90,18 +90,21 @@ export async function waitForHealth(
   const url = `http://${host}:${port}/health`;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(250),
+      });
       if (response.ok) {
         await response.text();
         return;
       }
+      await response.text();
     } catch {
       // Keep polling until the child is ready or exits.
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
 
-  throw new Error(`Timed out waiting for ${url}`);
+  throw new Error(`Timed out waiting for ${url} after ${attempts} attempts`);
 }
 
 export async function readChildOutput(child: SpawnedChild): Promise<string> {


### PR DESCRIPTION
## Summary
- extend Tufa agent CLI health polling for slower encrypted-store startup on release runners
- race readiness against child-process exit so failures remain diagnostic
- add per-request health timeouts to avoid a hung fetch consuming the whole readiness window
- add an empty changeset because this is a test-only release-gate fix

## Verification
- deno task fmt:check
- deno test -A packages/tufa/test/integration/agent-cli.test.ts *(blocked locally by Deno macOS N-API cleanup-hook panic during spawned tufa init; GitHub Linux CI is the authoritative check for this failure)*