### PR TITLE
Add DID Webs resolver and interop support

### DIFF
--- a/.changeset/did-webs-tufa.md
+++ b/.changeset/did-webs-tufa.md
@@ -1,0 +1,6 @@
+---
+"keri-ts": minor
+"@keri-ts/tufa": minor
+---
+
+Add did:webs and did:keri resolver support, DID Webs artifact generation, designated-alias binding, and Tufa resolver commands.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.deno-cache
+.test-timings
+.cache
+.pytest_cache
+coverage
+dist
+build
+node_modules
+packages/*/node_modules
+packages/*/npm
+packages/*/dist
+packages/*/coverage
+*.log
+Dockerfile

--- a/.github/workflows/did-webs-ts-docker.yml
+++ b/.github/workflows/did-webs-ts-docker.yml
@@ -1,0 +1,46 @@
+name: DID Webs TS Docker
+
+on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push images to GHCR after the interop container passes"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  DID_WEBS_TS_IMAGE_NAMESPACE: ghcr.io/kentbull
+  DID_WEBS_TS_TAG: ${{ github.sha }}
+
+jobs:
+  build-test-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: build DID Webs TS images
+        run: bash scripts/docker/did-webs-ts.sh build
+
+      - name: run DID Webs interop matrix in Docker
+        run: |
+          mkdir -p .test-timings
+          docker run --rm \
+            --volume "${PWD}/.test-timings:/app/.test-timings" \
+            "${DID_WEBS_TS_IMAGE_NAMESPACE}/did-webs-ts-interop:${DID_WEBS_TS_TAG}"
+
+      - name: log in to GHCR
+        if: ${{ inputs.push == 'true' }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: push DID Webs TS images
+        if: ${{ inputs.push == 'true' }}
+        run: bash scripts/docker/did-webs-ts.sh push

--- a/.github/workflows/pr-stage-gate.yml
+++ b/.github/workflows/pr-stage-gate.yml
@@ -49,6 +49,10 @@ env:
   KERIPY_GIT_URL: https://github.com/kentbull/keripy.git
   KERIPY_GIT_SHA: 450ae1c2a7eac61d92bc7b830cb6883c41e6a798
   KERIPY_VENV: ${{ github.workspace }}/.cache/keripy-venv
+  DID_WEBS_RESOLVER_GIT_URL: https://github.com/kentbull/did-webs-resolver.git
+  DID_WEBS_RESOLVER_GIT_REF: refs/heads/clean-up-deps
+  DID_WEBS_RESOLVER_GIT_SHA: 8395277f32b37129fa6ef734c9f3902bb6cbbcbc
+  DID_WEBS_RESOLVER_PYTHON_VERSION: "3.13"
   LMDB_DATA_V1: "true"
   NODE_VERSION: "25.9.0"
   PYTHON_VERSION: "3.14"
@@ -56,6 +60,7 @@ env:
   NODE_MODULES_CACHE_KEY_PREFIX: ci-node-modules-v1
   INTEROP_NODE_MODULES_CACHE_KEY_PREFIX: interop-node-modules-v3
   KERIPY_CACHE_KEY_PREFIX: keripy-v2-mailbox-impl
+  DID_WEBS_RESOLVER_CACHE_KEY_PREFIX: did-webs-resolver-v1
   KERI_TEST_TIMINGS_DIR: ${{ github.workspace }}/.test-timings
 
 jobs:
@@ -866,6 +871,136 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  keri-interop-did-webs-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: ${{ env.DENO_VERSION }}
+
+      - name: restore Deno dependency cache
+        id: deno-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ env.DENO_DIR }}
+          key: ${{ runner.os }}-${{ env.DENO_CACHE_KEY_PREFIX }}-deno-${{ env.DENO_VERSION }}-${{ hashFiles('deno.lock', 'deno.json', 'dprint.json', 'packages/keri/deno.json', 'packages/cesr/deno.json', 'packages/tufa/deno.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.DENO_CACHE_KEY_PREFIX }}-deno-${{ env.DENO_VERSION }}-
+
+      - name: restore interop LMDB node_modules cache
+        id: interop-node-modules-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.INTEROP_NODE_MODULES_CACHE_KEY_PREFIX }}-node-${{ env.NODE_VERSION }}-lmdb-data-v1-${{ hashFiles('deno.lock', 'deno.json', 'package-lock.json', 'package.json', 'packages/keri/deno.json', 'packages/cesr/deno.json', 'packages/tufa/deno.json', 'packages/keri/package.json', 'packages/cesr/package.json', 'packages/tufa/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.INTEROP_NODE_MODULES_CACHE_KEY_PREFIX }}-node-${{ env.NODE_VERSION }}-lmdb-data-v1-
+
+      - name: install deterministic workspace dependencies
+        if: steps.interop-node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci --ignore-scripts
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: capture KERIpy Python
+        run: echo "KERIPY_INTEROP_PYTHON=$(python -c 'import sys; print(sys.executable)')" >> "$GITHUB_ENV"
+
+      - name: rebuild LMDB-js with data v1 compatibility
+        if: steps.interop-node-modules-cache.outputs.cache-hit != 'true'
+        run: |
+          cd packages/keri
+          deno task setup:compat-lmdb
+
+      - name: restore KERIpy virtualenv cache
+        id: keripy-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ env.KERIPY_VENV }}
+          key: ${{ runner.os }}-${{ env.KERIPY_CACHE_KEY_PREFIX }}-python-${{ env.PYTHON_VERSION }}-keripy-${{ env.KERIPY_GIT_SHA }}
+
+      - name: install pinned KERIpy CLI
+        if: steps.keripy-cache.outputs.cache-hit != 'true'
+        run: |
+          python -m venv "${KERIPY_VENV}"
+          "${KERIPY_VENV}/bin/python" -m pip install --upgrade pip
+          "${KERIPY_VENV}/bin/python" -m pip install "git+${KERIPY_GIT_URL}@${KERIPY_GIT_SHA}"
+
+      - name: add KERIpy CLI to PATH
+        run: echo "${KERIPY_VENV}/bin" >> "$GITHUB_PATH"
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ env.DID_WEBS_RESOLVER_PYTHON_VERSION }}
+
+      - name: capture did-webs-resolver Python
+        run: echo "DID_WEBS_RESOLVER_PYTHON=$(python -c 'import sys; print(sys.executable)')" >> "$GITHUB_ENV"
+
+      - name: restore pinned did-webs-resolver cache
+        id: did-webs-resolver-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/tufa-interop/did-webs-resolver/${{ env.DID_WEBS_RESOLVER_GIT_SHA }}
+          key: ${{ runner.os }}-${{ env.DID_WEBS_RESOLVER_CACHE_KEY_PREFIX }}-python-${{ env.DID_WEBS_RESOLVER_PYTHON_VERSION }}-${{ env.DID_WEBS_RESOLVER_GIT_SHA }}
+
+      - name: assert environment
+        env:
+          EXPECTED_DENO_VERSION: ${{ env.DENO_VERSION }}
+          EXPECTED_NODE_VERSION: ${{ env.NODE_VERSION }}
+          EXPECT_KLI: "true"
+        run: |
+          bash scripts/ci/assert-environment.sh
+          echo "did-webs-resolver ref: ${DID_WEBS_RESOLVER_GIT_URL}@${DID_WEBS_RESOLVER_GIT_REF}"
+          echo "did-webs-resolver sha: ${DID_WEBS_RESOLVER_GIT_SHA}"
+          "${DID_WEBS_RESOLVER_PYTHON}" --version
+
+      - name: run DID Webs interop matrix
+        run: deno task test:quality:keri:interop-did-webs
+
+      - name: upload DID Webs interop timings
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: keri-interop-did-webs-timings-pr-${{ github.event.pull_request.number }}
+          path: .test-timings/*.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  keri-interop-did-webs-docker-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: build DID Webs TS interop image
+        run: docker build --file docker/did-webs-ts/Dockerfile --target interop --tag did-webs-ts-interop:ci .
+
+      - name: run DID Webs interop matrix in Docker
+        run: |
+          mkdir -p .test-timings
+          docker run --rm \
+            --volume "${PWD}/.test-timings:/app/.test-timings" \
+            did-webs-ts-interop:ci
+
+      - name: upload Docker DID Webs interop timings
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: keri-interop-did-webs-docker-timings-pr-${{ github.event.pull_request.number }}
+          path: .test-timings/*.json
+          if-no-files-found: warn
+          retention-days: 14
+
   # CESR remains a separate job because it is fast and independent; splitting it
   # out improves feedback latency and makes failures easier to localize.
   cesr-tests:
@@ -1050,6 +1185,8 @@ jobs:
       - keri-interop-parity-tests
       - keri-interop-gates-b-tests
       - keri-interop-gates-c-tests
+      - keri-interop-did-webs-tests
+      - keri-interop-did-webs-docker-tests
       - cesr-tests
       - package-smoke
     runs-on: ubuntu-latest
@@ -1073,6 +1210,8 @@ jobs:
           KERI_INTEROP_PARITY_TESTS: ${{ needs.keri-interop-parity-tests.result }}
           KERI_INTEROP_GATES_B_TESTS: ${{ needs.keri-interop-gates-b-tests.result }}
           KERI_INTEROP_GATES_C_TESTS: ${{ needs.keri-interop-gates-c-tests.result }}
+          KERI_INTEROP_DID_WEBS_TESTS: ${{ needs.keri-interop-did-webs-tests.result }}
+          KERI_INTEROP_DID_WEBS_DOCKER_TESTS: ${{ needs.keri-interop-did-webs-docker-tests.result }}
           CESR_TESTS: ${{ needs.cesr-tests.result }}
           PACKAGE_SMOKE: ${{ needs.package-smoke.result }}
         run: |
@@ -1090,6 +1229,8 @@ jobs:
           echo "keri-interop-parity-tests=${KERI_INTEROP_PARITY_TESTS}"
           echo "keri-interop-gates-b-tests=${KERI_INTEROP_GATES_B_TESTS}"
           echo "keri-interop-gates-c-tests=${KERI_INTEROP_GATES_C_TESTS}"
+          echo "keri-interop-did-webs-tests=${KERI_INTEROP_DID_WEBS_TESTS}"
+          echo "keri-interop-did-webs-docker-tests=${KERI_INTEROP_DID_WEBS_DOCKER_TESTS}"
           echo "cesr-tests=${CESR_TESTS}"
           echo "package-smoke=${PACKAGE_SMOKE}"
           [[ "${STATIC_CHECKS}" == "success" ]]
@@ -1106,5 +1247,7 @@ jobs:
           [[ "${KERI_INTEROP_PARITY_TESTS}" == "success" ]]
           [[ "${KERI_INTEROP_GATES_B_TESTS}" == "success" ]]
           [[ "${KERI_INTEROP_GATES_C_TESTS}" == "success" ]]
+          [[ "${KERI_INTEROP_DID_WEBS_TESTS}" == "success" ]]
+          [[ "${KERI_INTEROP_DID_WEBS_DOCKER_TESTS}" == "success" ]]
           [[ "${CESR_TESTS}" == "success" ]]
           [[ "${PACKAGE_SMOKE}" == "success" ]]

--- a/deno.json
+++ b/deno.json
@@ -60,6 +60,7 @@
     "test:quality:keri:interop-delegation": "cd packages/keri && deno task test:quality:interop-delegation",
     "test:quality:keri:interop-mailbox-slow": "cd packages/keri && deno task test:quality:interop-mailbox-slow",
     "test:quality:keri:interop-witness": "cd packages/keri && deno task test:quality:interop-witness",
+    "test:quality:keri:interop-did-webs": "cd packages/keri && deno task test:quality:interop-did-webs",
     "test:quality:keri:interop-gates-b": "cd packages/keri && deno task test:quality:interop-gates-b",
     "test:quality:keri:interop-gates-c": "cd packages/keri && deno task test:quality:interop-gates-c",
     "test:integration:server": "cd packages/tufa && deno task test:integration:server",
@@ -69,7 +70,11 @@
     "tephra:annotate": "cd packages/cesr && deno task annotate",
     "tephra:validate": "cd packages/cesr && deno task validate",
     "tephra:build:npm": "deno task version:generate && cd packages/cesr && deno task build:npm",
-    "npm:build:all": "deno task build:npm && deno task tephra:build:npm && deno task tufa:build:npm"
+    "npm:build:all": "deno task build:npm && deno task tephra:build:npm && deno task tufa:build:npm",
+    "docker:did-webs-ts:build": "bash scripts/docker/did-webs-ts.sh build",
+    "docker:did-webs-ts:test": "bash scripts/docker/did-webs-ts.sh test",
+    "docker:did-webs-ts:push": "bash scripts/docker/did-webs-ts.sh push",
+    "docker:did-webs-ts:build-push": "bash scripts/docker/did-webs-ts.sh build-push"
   },
   "fmt": {
     "include": [

--- a/docker/did-webs-ts/Dockerfile
+++ b/docker/did-webs-ts/Dockerfile
@@ -1,0 +1,55 @@
+ARG NODE_IMAGE_TAG=25.9.0-bookworm-slim
+FROM node:${NODE_IMAGE_TAG} AS base
+
+ARG DENO_VERSION=2.8.2
+ENV DENO_INSTALL=/usr/local \
+  DENO_DIR=/deno-dir \
+  XDG_CACHE_HOME=/root/.cache \
+  PIP_DISABLE_PIP_VERSION_CHECK=1
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libsodium-dev \
+    libsodium23 \
+    pkg-config \
+    python3 \
+    unzip \
+    xz-utils \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deno.land/install.sh | sh -s "v${DENO_VERSION}" \
+  && deno --version
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
+  && uv --version
+
+WORKDIR /app
+
+COPY package.json package-lock.json deno.json deno.lock dprint.json ./
+COPY packages ./packages
+COPY scripts ./scripts
+COPY docker/did-webs-ts/run-interop.sh /usr/local/bin/did-webs-ts-interop
+
+RUN chmod +x /usr/local/bin/did-webs-ts-interop
+RUN npm ci --ignore-scripts
+RUN npm install -g node-gyp
+RUN cd packages/keri && deno task setup:compat-lmdb
+RUN deno cache --unstable-ffi \
+  packages/tufa/mod.ts \
+  packages/keri/test/integration/app/interop-did-webs-resolver-matrix.test.ts
+
+FROM base AS runtime
+
+ENTRYPOINT ["deno", "run", "--allow-all", "--unstable-ffi", "packages/tufa/mod.ts"]
+CMD ["--help"]
+
+FROM base AS interop
+
+RUN uv python install 3.13 3.14
+
+ENTRYPOINT ["did-webs-ts-interop"]

--- a/docker/did-webs-ts/run-interop.sh
+++ b/docker/did-webs-ts/run-interop.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export HOME="${HOME:-/root}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/root/.cache}"
+export KERIPY_INTEROP_PYTHON="${KERIPY_INTEROP_PYTHON:-$(uv python find 3.14)}"
+export DID_WEBS_RESOLVER_PYTHON="${DID_WEBS_RESOLVER_PYTHON:-$(uv python find 3.13)}"
+
+if [[ $# -gt 0 ]]; then
+  exec "$@"
+fi
+
+exec deno task test:quality:keri:interop-did-webs

--- a/packages/keri/deno.json
+++ b/packages/keri/deno.json
@@ -45,6 +45,7 @@
     "test:quality:interop-delegation": "bash ../../scripts/ci/run-keri-test-group.sh interop-delegation",
     "test:quality:interop-mailbox-slow": "bash ../../scripts/ci/run-keri-test-group.sh interop-mailbox-slow",
     "test:quality:interop-witness": "bash ../../scripts/ci/run-keri-test-group.sh interop-witness",
+    "test:quality:interop-did-webs": "bash ../../scripts/ci/run-keri-test-group.sh interop-did-webs",
     "test:quality:interop-gates-b": "bash ../../scripts/ci/run-keri-test-group.sh interop-gates-b",
     "test:quality:interop-gates-c": "bash ../../scripts/ci/run-keri-test-group.sh interop-gates-c",
     "test:slow:runtime": "bash ../../scripts/ci/run-keri-test-group.sh runtime-slow",

--- a/packages/keri/src/app/cli/did.ts
+++ b/packages/keri/src/app/cli/did.ts
@@ -1,0 +1,252 @@
+/**
+ * DID-related CLI operations shared by the Tufa command dispatcher.
+ */
+import { type Operation } from "effection";
+import { ValidationError } from "../../core/errors.ts";
+import { Reger } from "../../db/reger.ts";
+import {
+  bindDesignatedAliases,
+  DEFAULT_DESIGNATED_ALIASES_REGISTRY_NAME,
+  generateDidWebsArtifacts,
+  parseDidWebs,
+  resolveDidKeri,
+  resolveDidWebs,
+} from "../../did/index.ts";
+import { type AgentRuntime, createAgentRuntime } from "../agent-runtime.ts";
+import type { Habery } from "../habbing.ts";
+import { WitnessReceiptor } from "../witnessing.ts";
+import { setupHby } from "./common/existing.ts";
+
+interface DidBaseArgs {
+  name?: string;
+  base?: string;
+  headDirPath?: string;
+  passcode?: string;
+  compat?: boolean;
+}
+
+interface DwsBindArgs extends DidBaseArgs {
+  alias?: string;
+  dids: string[];
+  registryName?: string;
+  createRegistry?: boolean;
+  allowExternalDid?: boolean;
+}
+
+interface DwsGenerateArgs extends DidBaseArgs {
+  alias?: string;
+  did?: string;
+  outputDir?: string;
+  meta?: boolean;
+}
+
+interface DwsResolveArgs extends DidBaseArgs {
+  did?: string;
+  meta?: boolean;
+  insecureHttp?: boolean;
+}
+
+interface DkrResolveArgs extends DidBaseArgs {
+  did?: string;
+  oobis: string[];
+  meta?: boolean;
+}
+
+/** Implement `tufa dws bind`. */
+export function* dwsBindCommand(args: Record<string, unknown>): Operation<void> {
+  const commandArgs: DwsBindArgs = {
+    ...baseArgs(args),
+    alias: args.alias as string | undefined,
+    dids: asStringList(args.did),
+    registryName: args.registryName as string | undefined,
+    createRegistry: args.createRegistry as boolean | undefined,
+    allowExternalDid: args.allowExternalDid as boolean | undefined,
+  };
+  requireNonEmpty(commandArgs.alias, "Alias");
+  const { hby, runtime } = yield* openRuntime(commandArgs);
+  try {
+    const hab = hby.habByName(commandArgs.alias!);
+    const priorSn = hab?.kever?.sn ?? 0;
+    const result = bindDesignatedAliases(runtime, {
+      alias: commandArgs.alias!,
+      dids: commandArgs.dids,
+      registryName: commandArgs.registryName ?? DEFAULT_DESIGNATED_ALIASES_REGISTRY_NAME,
+      createRegistry: commandArgs.createRegistry ?? true,
+      allowExternalDid: commandArgs.allowExternalDid ?? false,
+    });
+    if (hab?.pre) {
+      yield* receiptNewWitnessEvents(hby, hab.pre, priorSn);
+    }
+    console.log(JSON.stringify(result));
+  } finally {
+    yield* closeRuntime(hby, runtime);
+  }
+}
+
+/** Implement `tufa dws generate`. */
+export function* dwsGenerateCommand(args: Record<string, unknown>): Operation<void> {
+  const commandArgs: DwsGenerateArgs = {
+    ...baseArgs(args),
+    alias: args.alias as string | undefined,
+    did: args.did as string | undefined,
+    outputDir: args.outputDir as string | undefined,
+    meta: args.meta as boolean | undefined,
+  };
+  requireNonEmpty(commandArgs.alias, "Alias");
+  requireNonEmpty(commandArgs.did, "DID");
+  requireNonEmpty(commandArgs.outputDir, "Output directory");
+  const { hby, runtime } = yield* openRuntime(commandArgs);
+  try {
+    const artifacts = generateDidWebsArtifacts(runtime, {
+      alias: commandArgs.alias,
+      did: commandArgs.did!,
+      metadata: commandArgs.meta ?? false,
+    });
+    const parsed = parseDidWebs(commandArgs.did!);
+    const dir = artifactOutputDir(
+      commandArgs.outputDir!,
+      parsed.path,
+      artifacts.aid,
+    );
+    Deno.mkdirSync(dir, { recursive: true });
+    Deno.writeFileSync(`${dir}/did.json`, artifacts.didJson);
+    Deno.writeFileSync(`${dir}/keri.cesr`, artifacts.keriCesr);
+    console.log(JSON.stringify({
+      aid: artifacts.aid,
+      did: commandArgs.did,
+      didJson: `${dir}/did.json`,
+      keriCesr: `${dir}/keri.cesr`,
+    }));
+  } finally {
+    yield* closeRuntime(hby, runtime);
+  }
+}
+
+/** Implement `tufa dws resolve`. */
+export function* dwsResolveCommand(args: Record<string, unknown>): Operation<void> {
+  const commandArgs: DwsResolveArgs = {
+    ...baseArgs(args),
+    did: args.did as string | undefined,
+    meta: args.meta as boolean | undefined,
+    insecureHttp: args.insecureHttp as boolean | undefined,
+  };
+  requireNonEmpty(commandArgs.did, "DID");
+  const { hby, runtime } = yield* openRuntime(commandArgs);
+  try {
+    const result = yield* resolveDidWebs(runtime, {
+      did: commandArgs.did!,
+      metadata: commandArgs.meta ?? false,
+      insecureHttp: commandArgs.insecureHttp ?? false,
+    });
+    console.log(JSON.stringify(commandArgs.meta ? result.resolution : result.document, null, 2));
+  } finally {
+    yield* closeRuntime(hby, runtime);
+  }
+}
+
+/** Implement `tufa dkr resolve`. */
+export function* dkrResolveCommand(args: Record<string, unknown>): Operation<void> {
+  const commandArgs: DkrResolveArgs = {
+    ...baseArgs(args),
+    did: args.did as string | undefined,
+    oobis: asStringList(args.oobi),
+    meta: args.meta as boolean | undefined,
+  };
+  requireNonEmpty(commandArgs.did, "DID");
+  const { hby, runtime } = yield* openRuntime(commandArgs);
+  try {
+    const result = yield* resolveDidKeri(runtime, {
+      did: commandArgs.did!,
+      oobis: commandArgs.oobis,
+      metadata: commandArgs.meta ?? false,
+    });
+    console.log(JSON.stringify(commandArgs.meta ? result.resolution : result.document, null, 2));
+  } finally {
+    yield* closeRuntime(hby, runtime);
+  }
+}
+
+function baseArgs(args: Record<string, unknown>): DidBaseArgs {
+  return {
+    name: args.name as string | undefined,
+    base: args.base as string | undefined,
+    headDirPath: args.headDirPath as string | undefined,
+    passcode: args.passcode as string | undefined,
+    compat: args.compat as boolean | undefined,
+  };
+}
+
+function* openRuntime(args: DidBaseArgs): Operation<{ hby: Habery; runtime: AgentRuntime; reger: Reger }> {
+  requireNonEmpty(args.name, "Name");
+  const hby = yield* setupHby(
+    args.name!,
+    args.base ?? "",
+    args.passcode,
+    false,
+    args.headDirPath,
+    {
+      compat: args.compat ?? false,
+      skipConfig: true,
+    },
+  );
+  const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+  const reger = runtime.vdr.reger;
+  if (!(reger instanceof Reger)) {
+    throw new ValidationError("VDR runtime did not open Reger.");
+  }
+  return { hby, runtime, reger };
+}
+
+function* closeRuntime(hby: Habery, runtime: AgentRuntime): Operation<void> {
+  yield* runtime.close();
+  yield* hby.close();
+}
+
+function requireNonEmpty(value: string | undefined, label: string): void {
+  if (!value || value.trim().length === 0) {
+    throw new ValidationError(`${label} is required.`);
+  }
+}
+
+function* receiptNewWitnessEvents(
+  hby: Habery,
+  pre: string,
+  priorSn: number,
+): Operation<void> {
+  const hab = hby.habs.get(pre);
+  const latestSn = hab?.kever?.sn;
+  if (!hab?.kever || latestSn === undefined || latestSn <= priorSn || hab.kever.wits.length === 0) {
+    return;
+  }
+  const receiptor = new WitnessReceiptor(hby);
+  for (let sn = priorSn + 1; sn <= latestSn; sn += 1) {
+    yield* receiptor.submit(pre, { sn });
+  }
+}
+
+function asStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string");
+  }
+  return typeof value === "string" ? [value] : [];
+}
+
+function artifactOutputDir(
+  root: string,
+  didPath: readonly string[],
+  aid: string,
+): string {
+  const normalizedRoot = root.replace(/\/+$/u, "");
+  return [
+    normalizedRoot,
+    ...didPath.map(safePathSegment),
+    safePathSegment(aid),
+  ].filter((part) => part.length > 0).join("/");
+}
+
+function safePathSegment(segment: string): string {
+  if (segment.includes("/") || segment === ".." || segment.includes("\0")) {
+    throw new ValidationError(`Unsafe DID path segment ${segment}.`);
+  }
+  return segment;
+}

--- a/packages/keri/src/app/cli/index.ts
+++ b/packages/keri/src/app/cli/index.ts
@@ -10,6 +10,7 @@ export { benchmarkCommand } from "./benchmark.ts";
 export { challengeGenerateCommand, challengeRespondCommand, challengeVerifyCommand } from "./challenge.ts";
 export { dumpEvts } from "./db-dump.ts";
 export { delegateConfirmCommand } from "./delegate.ts";
+export { dkrResolveCommand, dwsBindCommand, dwsGenerateCommand, dwsResolveCommand } from "./did.ts";
 export { endsAddCommand } from "./ends.ts";
 export { exchangeSendCommand } from "./exchange.ts";
 export { exportCommand } from "./export.ts";

--- a/packages/keri/src/app/protocol-host-policy.ts
+++ b/packages/keri/src/app/protocol-host-policy.ts
@@ -15,6 +15,14 @@ export interface ProtocolHostPolicy {
   hostedPrefixes?: readonly string[];
   /** Optional hosted witness habitat enabling witness-specific HTTP routes. */
   witnessHab?: Hab;
+  /** Static did:webs artifact root used by `tufa dws resolver --static-files-dir`. */
+  dwsStaticFilesDir?: string;
+  /** DID path prefix used by static and dynamic did:webs artifact routes. */
+  dwsDidPath?: string;
+  /** Whether dynamic did:webs artifact generation is enabled for hosted AIDs. */
+  dwsDynamic?: boolean;
+  /** Use http:// when this host resolves did:webs artifacts, for local workflows. */
+  dwsInsecureHttp?: boolean;
   /**
    * Whether non-`mbx` query POSTs may return immediate CESR reply/replay bodies.
    *

--- a/packages/keri/src/app/witnessing.ts
+++ b/packages/keri/src/app/witnessing.ts
@@ -33,7 +33,13 @@ import { type Scheme, Schemes } from "../core/schemes.ts";
 import { Baser } from "../db/basing.ts";
 import { dgKey } from "../db/core/keys.ts";
 import { type AgentRuntime, createAgentRuntime, settleRuntimeIngress } from "./agent-runtime.ts";
-import { buildCesrRequest, inspectCesrRequest, splitCesrStream } from "./cesr-http.ts";
+import {
+  buildCesrRequest,
+  CESR_CONTENT_TYPE,
+  inspectCesrRequest,
+  KERIPY_CESR_JSON_CONTENT_TYPE,
+  splitCesrStream,
+} from "./cesr-http.ts";
 import { acceptedEventReplayMessage, type Hab, type Habery } from "./habbing.ts";
 import { closeResponseBody, fetchResponseHandle } from "./httping.ts";
 import { envelopesFromFrames } from "./parsering.ts";
@@ -41,6 +47,11 @@ import { envelopesFromFrames } from "./parsering.ts";
 const WitnessReceiptPollAttempts = 20;
 const WitnessReceiptPollDelayMs = 100;
 const KERI_V1 = Object.freeze({ major: 1, minor: 0 } as const);
+const KERIPY_CONTENT_TYPE_ERROR = "content type";
+const WITNESS_HTTP_CONTENT_TYPES = [
+  CESR_CONTENT_TYPE,
+  KERIPY_CESR_JSON_CONTENT_TYPE,
+] as const;
 
 /** Supported witness-auth payloads keyed by witness AID. */
 export type WitnessAuthMap = Record<string, string>;
@@ -610,25 +621,53 @@ export function* sendWitnessMessage(
   }
 
   for (const part of splitCesrStream(bytes)) {
-    const request = buildCesrRequest(part, {
-      destination: witness,
-    });
-    const { response } = yield* fetchResponseHandle(url, {
-      method: "POST",
-      headers: {
-        ...request.headers,
-        ...(auth ? { Authorization: auth } : {}),
-      },
-      body: request.body,
-    });
-    if (!response.ok) {
+    let delivered = false;
+    let lastStatus = 0;
+    let lastText = "";
+    for (const contentType of WITNESS_HTTP_CONTENT_TYPES) {
+      const request = buildCesrRequest(part, {
+        contentType,
+        destination: witness,
+      });
+      const { response } = yield* fetchResponseHandle(url, {
+        method: "POST",
+        headers: {
+          ...request.headers,
+          ...(auth ? { Authorization: auth } : {}),
+        },
+        body: request.body,
+      });
+      if (response.ok) {
+        yield* closeResponseBody(response);
+        delivered = true;
+        break;
+      }
       const body = yield* readResponseBytes(response);
+      lastStatus = response.status;
+      lastText = new TextDecoder().decode(body);
+      if (isKeripyContentTypeRejection(response.status, contentType, lastText)) {
+        continue;
+      }
       throw new ValidationError(
-        `Witness delivery to ${witness} failed with HTTP ${response.status}: ${new TextDecoder().decode(body)}`,
+        `Witness delivery to ${witness} failed with HTTP ${response.status}: ${lastText}`,
       );
     }
-    yield* closeResponseBody(response);
+    if (!delivered) {
+      throw new ValidationError(
+        `Witness delivery to ${witness} failed with HTTP ${lastStatus}: ${lastText}`,
+      );
+    }
   }
+}
+
+function isKeripyContentTypeRejection(
+  status: number,
+  contentType: string,
+  responseText: string,
+): boolean {
+  return status === 406
+    && contentType === CESR_CONTENT_TYPE
+    && responseText.toLowerCase().includes(KERIPY_CONTENT_TYPE_ERROR);
 }
 
 /** Send one raw CESR stream to a TCP witness and close the socket after flush. */
@@ -722,39 +761,50 @@ function* postWitnessReceiptEndpoint(
     };
   }
 
-  const request = buildCesrRequest(message, {
-    destination: witness,
-  });
   const responseUrl = new URL(url);
   responseUrl.pathname = `${responseUrl.pathname.replace(/\/+$/, "") || ""}/receipts`;
-  const { response } = yield* fetchResponseHandle(responseUrl.toString(), {
-    method: "POST",
-    headers: {
-      ...request.headers,
-      ...(auth ? { Authorization: auth } : {}),
-    },
-    body: request.body,
-  });
-  if (response.status === 202) {
-    yield* closeResponseBody(response);
-    return { kind: "escrow", status: 202 };
-  }
-  if (response.status !== 200) {
+  let lastStatus = 0;
+  let lastText = "";
+  for (const contentType of WITNESS_HTTP_CONTENT_TYPES) {
+    const request = buildCesrRequest(message, {
+      contentType,
+      destination: witness,
+    });
+    const { response } = yield* fetchResponseHandle(responseUrl.toString(), {
+      method: "POST",
+      headers: {
+        ...request.headers,
+        ...(auth ? { Authorization: auth } : {}),
+      },
+      body: request.body,
+    });
+    if (response.status === 202) {
+      yield* closeResponseBody(response);
+      return { kind: "escrow", status: 202 };
+    }
+    if (response.status === 200) {
+      const body = yield* readResponseBytes(response);
+      const inspected = inspectReceiptMessage(body);
+      return {
+        kind: "accepted",
+        status: 200,
+        body,
+        wigers: inspected.wigers,
+        cigars: inspected.cigars,
+      };
+    }
     const body = yield* readResponseBytes(response);
-    return {
-      kind: "reject",
-      status: response.status,
-      message: new TextDecoder().decode(body),
-    };
+    lastStatus = response.status;
+    lastText = new TextDecoder().decode(body);
+    if (isKeripyContentTypeRejection(response.status, contentType, lastText)) {
+      continue;
+    }
+    return { kind: "reject", status: response.status, message: lastText };
   }
-  const body = yield* readResponseBytes(response);
-  const inspected = inspectReceiptMessage(body);
   return {
-    kind: "accepted",
-    status: 200,
-    body,
-    wigers: inspected.wigers,
-    cigars: inspected.cigars,
+    kind: "reject",
+    status: lastStatus,
+    message: lastText,
   };
 }
 
@@ -895,9 +945,7 @@ export class Receiptor {
         }
         statuses[witness] = response.status;
         if (response.kind !== "accepted") {
-          const detail = response.kind === "reject"
-            ? response.message
-            : "receipt remained escrowed";
+          const detail = response.kind === "reject" ? response.message : "receipt remained escrowed";
           throw new ValidationError(
             `Witness ${witness} failed to receipt ${pre}:${eventSn.toString(16)}: ${detail}`,
           );
@@ -1061,9 +1109,7 @@ export class WitnessReceiptor {
     }
     const eventSn = sn ?? kever.sn;
     const said = this.hby.db.kels.getLast(pre, eventSn);
-    const currentWitnessCount = said
-      ? this.hby.db.wigs.get(dgKey(pre, said)).length
-      : 0;
+    const currentWitnessCount = said ? this.hby.db.wigs.get(dgKey(pre, said)).length : 0;
     if (!this.force && currentWitnessCount >= kever.wits.length) {
       const statuses = Object.fromEntries(
         kever.wits.map((witness: string) => [witness, 200]),

--- a/packages/keri/src/did/index.ts
+++ b/packages/keri/src/did/index.ts
@@ -1,0 +1,7 @@
+/** DID support exported by the runtime surface. */
+export * from "./keri/resolving.ts";
+export * from "./webs/artifacts.ts";
+export * from "./webs/designated-aliases.ts";
+export * from "./webs/dids.ts";
+export * from "./webs/documenting.ts";
+export * from "./webs/resolving.ts";

--- a/packages/keri/src/did/keri/resolving.ts
+++ b/packages/keri/src/did/keri/resolving.ts
@@ -1,0 +1,52 @@
+/**
+ * `did:keri` resolution from local state and optional OOBI introduction.
+ */
+import type { Operation } from "effection";
+import type { AgentRuntime } from "../../app/agent-runtime.ts";
+import { processRuntimeTurn } from "../../app/agent-runtime.ts";
+import { ValidationError } from "../../core/errors.ts";
+import { parseDidKeriIdentifier } from "../webs/dids.ts";
+import {
+  type DidDocument,
+  type DidResolutionResult,
+  didResolutionResult,
+  generateBareDidDocument,
+} from "../webs/documenting.ts";
+
+export interface ResolveDidKeriOptions {
+  readonly did: string;
+  readonly oobis?: readonly string[];
+  readonly metadata?: boolean;
+}
+
+export interface ResolveDidKeriResult {
+  readonly did: string;
+  readonly document: DidDocument;
+  readonly resolution: DidResolutionResult;
+}
+
+/** Resolve one `did:keri` from current runtime state, resolving OOBIs first when supplied. */
+export function* resolveDidKeri(
+  runtime: AgentRuntime,
+  options: ResolveDidKeriOptions,
+): Operation<ResolveDidKeriResult> {
+  const parsed = parseDidKeriIdentifier(options.did);
+  for (const oobi of options.oobis ?? []) {
+    runtime.oobiery.resolve(oobi);
+  }
+  for (let i = 0; i < 5; i += 1) {
+    yield* processRuntimeTurn(runtime, { pollMailbox: false });
+    if (runtime.hby.db.getKever(parsed.aid, { refresh: true })) {
+      break;
+    }
+  }
+  if (!runtime.hby.db.getKever(parsed.aid, { refresh: true })) {
+    throw new ValidationError(`No accepted key state for ${parsed.aid}.`);
+  }
+  const document = generateBareDidDocument(runtime, parsed.canonical);
+  return {
+    did: parsed.canonical,
+    document,
+    resolution: didResolutionResult(document),
+  };
+}

--- a/packages/keri/src/did/webs/artifacts.ts
+++ b/packages/keri/src/did/webs/artifacts.ts
@@ -1,0 +1,126 @@
+/**
+ * Static/dynamic `did:webs` artifact generation.
+ *
+ * `did.json` is a hosted projection. `keri.cesr` is the replay stream a clean
+ * resolver needs to rebuild the same DID document from KERI/VDR state.
+ */
+import {
+  concatBytes,
+  Diger,
+  Prefixer,
+} from "../../../../cesr/mod.ts";
+import type { AgentRuntime } from "../../app/agent-runtime.ts";
+import type { Hab } from "../../app/habbing.ts";
+import { ValidationError } from "../../core/errors.ts";
+import { Roles } from "../../core/roles.ts";
+import { Reger } from "../../db/reger.ts";
+import { serializeCredential } from "../../vdr/credentialing.ts";
+import { listActiveDesignatedAliasCredentials, pinDesignatedAliasesSchema } from "./designated-aliases.ts";
+import { parseDidWebs } from "./dids.ts";
+import { generateDidDocument } from "./documenting.ts";
+
+export interface DidWebsArtifacts {
+  readonly aid: string;
+  readonly didJson: Uint8Array;
+  readonly keriCesr: Uint8Array;
+}
+
+export interface GenerateDidWebsArtifactsOptions {
+  readonly did: string;
+  readonly alias?: string;
+  readonly metadata?: boolean;
+}
+
+/** Generate both hosted artifacts for one local AID. */
+export function generateDidWebsArtifacts(
+  runtime: AgentRuntime,
+  options: GenerateDidWebsArtifactsOptions,
+): DidWebsArtifacts {
+  const parsed = parseDidWebs(options.did);
+  const hab = options.alias ? requireHab(runtime, options.alias) : runtime.hby.habs.get(parsed.aid);
+  if (!hab?.pre) {
+    throw new ValidationError(`No local AID found for did:webs AID ${parsed.aid}.`);
+  }
+  if (hab.pre !== parsed.aid) {
+    throw new ValidationError(
+      `DID ${options.did} embeds AID ${parsed.aid}, but alias ${hab.name} is ${hab.pre}.`,
+    );
+  }
+  pinDesignatedAliasesSchema(runtime);
+  const document = generateDidDocument(runtime, options.did, {
+    hosted: true,
+    metadata: options.metadata ?? false,
+  });
+  return {
+    aid: parsed.aid,
+    didJson: new TextEncoder().encode(`${JSON.stringify(document, null, 2)}\n`),
+    keriCesr: generateDidWebsCesr(runtime, parsed.aid, { hab }),
+  };
+}
+
+/** Generate the replay CESR stream for one local AID. */
+export function generateDidWebsCesr(
+  runtime: AgentRuntime,
+  aid: string,
+  options: { readonly hab?: Hab } = {},
+): Uint8Array {
+  const hab = options.hab ?? runtime.hby.habs.get(aid);
+  if (!hab?.pre) {
+    throw new ValidationError(`No local AID found for ${aid}.`);
+  }
+  const kever = runtime.hby.db.getKever(aid, { refresh: true });
+  if (!kever) {
+    throw new ValidationError(`No accepted key state for ${aid}.`);
+  }
+  const messages: Uint8Array[] = [];
+  if (kever.delegated) {
+    messages.push(...runtime.hby.db.cloneDelegation(kever));
+  }
+  messages.push(...runtime.hby.db.clonePreIter(aid));
+  messages.push(...endpointMessages(hab, aid));
+  messages.push(...designatedAliasMessages(runtime, aid));
+  return concatBytes(...messages.filter((message) => message.length > 0));
+}
+
+function endpointMessages(hab: Hab, aid: string): Uint8Array[] {
+  const messages: Uint8Array[] = [];
+  for (const role of [Roles.witness, Roles.agent, Roles.mailbox, Roles.controller]) {
+    messages.push(hab.replyEndRole(aid, role));
+  }
+  return messages;
+}
+
+function designatedAliasMessages(
+  runtime: AgentRuntime,
+  aid: string,
+): Uint8Array[] {
+  const reger = runtime.vdr.reger;
+  if (!(reger instanceof Reger)) {
+    throw new ValidationError("VDR runtime did not open Reger.");
+  }
+  const messages: Uint8Array[] = [];
+  for (const item of listActiveDesignatedAliasCredentials(runtime, aid)) {
+    const creder = item.creder;
+    if (!creder.regid || !creder.said) {
+      continue;
+    }
+    messages.push(...reger.clonePreIter(creder.regid));
+    messages.push(...reger.clonePreIter(creder.said));
+    const [clone, prefixer, number, diger] = reger.cloneCred(creder.said);
+    messages.push(serializeCredential(
+      clone,
+      prefixer as Prefixer,
+      number,
+      diger as Diger,
+    ));
+  }
+  return messages;
+}
+
+function requireHab(runtime: AgentRuntime, alias: string): Hab {
+  const hab = runtime.hby.habByName(alias);
+  if (!hab?.pre) {
+    throw new ValidationError(`No local AID found for alias ${alias}.`);
+  }
+  return hab;
+}

--- a/packages/keri/src/did/webs/designated-aliases-public-schema.json
+++ b/packages/keri/src/did/webs/designated-aliases-public-schema.json
@@ -1,0 +1,156 @@
+{
+  "$id": "EN6Oh5XSD5_q2Hgu-aqpdfbVepdpYpFlgz6zvJL5b_r5",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Designated Aliases Public Attestation",
+  "description": "A public attestation listing the designated aliases of an AID controller.",
+  "type": "object",
+  "credentialType": "DesignatedAliasesPublicAttestation",
+  "version": "1.0.0",
+  "properties": {
+    "v": {
+      "description": "Version",
+      "type": "string"
+    },
+    "d": {
+      "description": "Attestation SAID",
+      "type": "string"
+    },
+    "i": {
+      "description": "Controller AID",
+      "type": "string"
+    },
+    "ri": {
+      "description": "Attestation status registry",
+      "type": "string"
+    },
+    "s": {
+      "description": "schema section",
+      "oneOf": [
+        {
+          "description": "schema section SAID",
+          "type": "string"
+        },
+        {
+          "description": "schema detail",
+          "type": "object"
+        }
+      ]
+    },
+    "a": {
+      "oneOf": [
+        {
+          "description": "Attributes block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EBMVc1eOhOaA7MdwAlAX3KcvJRTpFrc7_xcB_XveYAEE",
+          "description": "Attributes block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Attributes block SAID",
+              "type": "string"
+            },
+            "dt": {
+              "description": "Designation date time",
+              "type": "string",
+              "format": "date-time"
+            },
+            "ids": {
+              "description": "List of namespaced/controlled AID aliases designated by the AID controller",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "dt",
+            "ids"
+          ]
+        }
+      ]
+    },
+    "r": {
+      "oneOf": [
+        {
+          "description": "Rules block SAID",
+          "type": "string"
+        },
+        {
+          "$id": "EHbxC6vD0mU49geUxIfcQtTxP2tAqay7QCz3CVzfSdHz",
+          "description": "Rules block",
+          "type": "object",
+          "properties": {
+            "d": {
+              "description": "Rules block SAID",
+              "type": "string"
+            },
+            "aliasDesignation": {
+              "description": "Alias designation",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "type": "string",
+                  "const": "The issuer of this ACDC designates the identifiers in the ids field as the only allowed namespaced aliases of the issuer's AID."
+                }
+              }
+            },
+            "usageDisclaimer": {
+              "description": "Usage Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Limitation of designation scope",
+                  "type": "string",
+                  "const": "This attestation only asserts designated aliases of the controller of the AID, that the AID controlled namespaced alias has been designated by the controller. It does not assert that the controller of this AID has control over the infrastructure or anything else related to the namespace other than the included AID."
+                }
+              }
+            },
+            "issuanceDisclaimer": {
+              "description": "Issuance Disclaimer",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "description": "Accuracy of information",
+                  "type": "string",
+                  "const": "All information in a valid and non-revoked alias designation assertion is accurate as of the date specified."
+                }
+              }
+            },
+            "termsOfUse": {
+              "description": "Terms of use",
+              "type": "object",
+              "properties": {
+                "l": {
+                  "type": "string",
+                  "const": "Designated aliases of the AID must only be used in a manner consistent with the expressed intent of the AID controller."
+                }
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "d",
+            "aliasDesignation",
+            "usageDisclaimer",
+            "issuanceDisclaimer",
+            "termsOfUse"
+          ]
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "v",
+    "d",
+    "i",
+    "ri",
+    "s",
+    "a",
+    "r"
+  ]
+}

--- a/packages/keri/src/did/webs/designated-aliases.ts
+++ b/packages/keri/src/did/webs/designated-aliases.ts
@@ -1,0 +1,327 @@
+/**
+ * Designated-alias ACDC support for `did:webs`.
+ *
+ * Responsibilities:
+ * - pin the public DA schema before issuing or verifying DA credentials
+ * - issue replacement DA credentials for one local AID
+ * - expose one active-state query shared by DID documents and CESR artifacts
+ */
+import {
+  DigDex,
+  Ilks,
+  Kinds,
+  Saider,
+  type SerderACDC,
+} from "../../../../cesr/mod.ts";
+import type { AgentRuntime } from "../../app/agent-runtime.ts";
+import type { Hab } from "../../app/habbing.ts";
+import { Verifier } from "../../app/verifying.ts";
+import { ValidationError } from "../../core/errors.ts";
+import { Schemer } from "../../core/scheming.ts";
+import type { Reger } from "../../db/reger.ts";
+import { Credentialer, CredentialWallet, Regery, Registry } from "../../vdr/credentialing.ts";
+import { Tevery } from "../../vdr/eventing.ts";
+import DESIGNATED_ALIASES_SCHEMA_RESOURCE from "./designated-aliases-public-schema.json" with { type: "json" };
+import { isDidString, parseDid } from "./dids.ts";
+
+export const DESIGNATED_ALIASES_SCHEMA_SAID = "EN6Oh5XSD5_q2Hgu-aqpdfbVepdpYpFlgz6zvJL5b_r5";
+
+export const DEFAULT_DESIGNATED_ALIASES_REGISTRY_NAME = "dws-designated-aliases";
+
+export interface ActiveDesignatedAliasCredential {
+  readonly creder: SerderACDC;
+  readonly aliases: readonly string[];
+}
+
+export interface BindDesignatedAliasesOptions {
+  readonly alias: string;
+  readonly dids: readonly string[];
+  readonly registryName?: string;
+  readonly createRegistry?: boolean;
+  readonly allowExternalDid?: boolean;
+}
+
+export interface BindDesignatedAliasesResult {
+  readonly aid: string;
+  readonly registry: string;
+  readonly registryName: string;
+  readonly issued: string;
+  readonly revoked: readonly string[];
+  readonly aliases: readonly string[];
+}
+
+/** Pin the public DA schema into a Habery schema cache. */
+export function pinDesignatedAliasesSchema(runtime: AgentRuntime): Schemer {
+  const schemer = new Schemer({
+    sed: cloneJsonObject(DESIGNATED_ALIASES_SCHEMA_RESOURCE),
+  });
+  if (schemer.said !== DESIGNATED_ALIASES_SCHEMA_SAID) {
+    throw new ValidationError(
+      `Embedded designated-alias schema SAID ${schemer.said} does not match ${DESIGNATED_ALIASES_SCHEMA_SAID}.`,
+    );
+  }
+  runtime.hby.db.schema.pin(schemer.said, schemer);
+  return schemer;
+}
+
+/**
+ * Issue a replacement DA credential for one local AID.
+ *
+ * Existing active DA credentials from the same issuer/schema are revoked before
+ * the replacement credential is issued.
+ */
+export function bindDesignatedAliases(
+  runtime: AgentRuntime,
+  options: BindDesignatedAliasesOptions,
+): BindDesignatedAliasesResult {
+  const hab = requireHab(runtime, options.alias);
+  const aid = hab.pre;
+  const aliases = normalizeAliasList(options.dids);
+  if (aliases.length === 0) {
+    throw new ValidationError("At least one --did value is required.");
+  }
+  for (const did of aliases) {
+    validateAliasDidForAid(did, aid, options.allowExternalDid ?? false);
+  }
+
+  pinDesignatedAliasesSchema(runtime);
+  const rgy = requireRegery(runtime);
+  const reger = requireReger(runtime);
+  const registryName = options.registryName ?? DEFAULT_DESIGNATED_ALIASES_REGISTRY_NAME;
+  const registry = designatedAliasRegistry(
+    rgy,
+    registryName,
+    hab,
+    options.createRegistry ?? true,
+  );
+
+  const active = listActiveDesignatedAliasCredentials(runtime, aid);
+  const revoked: string[] = [];
+  for (const item of active) {
+    const said = credentialSaid(item.creder);
+    registryForCredential(runtime, item.creder).revoke(said);
+    revoked.push(said);
+  }
+
+  const credentialer = new Credentialer(runtime.hby, {
+    reger,
+    vry: requireVerifier(runtime),
+  });
+  const creder = credentialer.create({
+    registry,
+    schema: DESIGNATED_ALIASES_SCHEMA_SAID,
+    data: { ids: aliases },
+    rules: designatedAliasRules(),
+  });
+  const issued = credentialer.issue(registry, creder);
+  if (issued.verifierDecision.kind !== "accept") {
+    throw new ValidationError(
+      `Designated-alias credential was not saved: ${issued.verifierDecision.kind}.`,
+    );
+  }
+  return {
+    aid,
+    registry: registry.regk ?? "",
+    registryName,
+    issued: credentialSaid(creder),
+    revoked,
+    aliases,
+  };
+}
+
+/** List active, unrevoked DA credentials issued by one AID. */
+export function listActiveDesignatedAliasCredentials(
+  runtime: AgentRuntime,
+  aid: string,
+): ActiveDesignatedAliasCredential[] {
+  const reger = requireReger(runtime);
+  const tvy = requireTevery(runtime);
+  const wallet = new CredentialWallet(reger);
+  const active: ActiveDesignatedAliasCredential[] = [];
+  for (
+    const said of wallet.list({
+      issued: true,
+      aid,
+      schema: DESIGNATED_ALIASES_SCHEMA_SAID,
+    }).sort()
+  ) {
+    const [creder] = reger.cloneCred(said);
+    const state = creder.regid ? tvy.tevers.get(creder.regid)?.vcState(said) : null;
+    if (!state || !isActiveCredentialState(state.et)) {
+      continue;
+    }
+    active.push({
+      creder,
+      aliases: extractDesignatedAliases(creder),
+    });
+  }
+  return active;
+}
+
+/** Extract `a.ids` from one DA credential body. */
+export function extractDesignatedAliases(creder: SerderACDC): string[] {
+  const attrib = creder.attrib;
+  if (!isRecord(attrib)) {
+    return [];
+  }
+  const ids = attrib.ids;
+  return Array.isArray(ids)
+    ? ids.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function isActiveCredentialState(et: unknown): boolean {
+  return et === Ilks.iss || et === Ilks.bis;
+}
+
+function designatedAliasRules(): Record<string, unknown> {
+  const rules = {
+    d: "",
+    aliasDesignation: {
+      l: "The issuer of this ACDC designates the identifiers in the ids field as the only allowed namespaced aliases of the issuer's AID.",
+    },
+    usageDisclaimer: {
+      l: "This attestation only asserts designated aliases of the controller of the AID, that the AID controlled namespaced alias has been designated by the controller. It does not assert that the controller of this AID has control over the infrastructure or anything else related to the namespace other than the included AID.",
+    },
+    issuanceDisclaimer: {
+      l: "All information in a valid and non-revoked alias designation assertion is accurate as of the date specified.",
+    },
+    termsOfUse: {
+      l: "Designated aliases of the AID must only be used in a manner consistent with the expressed intent of the AID controller.",
+    },
+  };
+  return Saider.saidify(rules, {
+    label: "d",
+    code: DigDex.Blake3_256,
+    kind: Kinds.json,
+  }).sad;
+}
+
+function validateAliasDidForAid(
+  did: string,
+  aid: string,
+  allowExternalDid: boolean,
+): void {
+  if (!isDidString(did)) {
+    throw new ValidationError(`Alias ${did} is not a DID.`);
+  }
+  let parsed;
+  try {
+    parsed = parseDid(did);
+  } catch {
+    if (allowExternalDid) {
+      return;
+    }
+    throw new ValidationError(
+      `Unsupported DID alias ${did}; pass --allow-external-did to self-attest opaque DID methods.`,
+    );
+  }
+  if (parsed.aid !== aid) {
+    throw new ValidationError(
+      `Alias ${did} embeds AID ${parsed.aid}, expected ${aid}.`,
+    );
+  }
+}
+
+function normalizeAliasList(dids: readonly string[]): string[] {
+  return [...new Set(dids.map((did) => did.trim()).filter((did) => did.length > 0))].sort();
+}
+
+function registryForCredential(
+  runtime: AgentRuntime,
+  creder: SerderACDC,
+): Registry {
+  const regid = creder.regid;
+  const rgy = requireRegery(runtime);
+  for (const registry of rgy.registries.values()) {
+    if (registry.regk === regid) {
+      return registry;
+    }
+  }
+  throw new ValidationError(`Registry ${regid ?? "<missing>"} not found for DA credential ${credentialSaid(creder)}.`);
+}
+
+function designatedAliasRegistry(
+  rgy: Regery,
+  registryName: string,
+  hab: Hab,
+  createRegistry: boolean,
+): Registry {
+  let registry = rgy.registryByName(registryName);
+  if (registry) {
+    if (registry.hab.pre !== hab.pre) {
+      throw new ValidationError(
+        `Registry ${registryName} belongs to ${registry.hab.pre}, not ${hab.pre}.`,
+      );
+    }
+    return registry;
+  }
+
+  rgy.loadRegistries();
+  registry = rgy.registryByName(registryName);
+  if (registry) {
+    if (registry.hab.pre !== hab.pre) {
+      throw new ValidationError(
+        `Registry ${registryName} belongs to ${registry.hab.pre}, not ${hab.pre}.`,
+      );
+    }
+    return registry;
+  }
+
+  if (!createRegistry) {
+    throw new ValidationError(`Registry ${registryName} not found.`);
+  }
+  return rgy.makeRegistry(registryName, hab, { noBackers: true });
+}
+
+function credentialSaid(creder: SerderACDC): string {
+  if (!creder.said) {
+    throw new ValidationError("Credential is missing SAID.");
+  }
+  return creder.said;
+}
+
+function requireHab(runtime: AgentRuntime, alias: string): Hab {
+  const hab = runtime.hby.habByName(alias);
+  if (!hab?.pre) {
+    throw new ValidationError(`No local AID found for alias ${alias}.`);
+  }
+  return hab;
+}
+
+function requireReger(runtime: AgentRuntime): Reger {
+  const reger = runtime.vdr.reger;
+  if (!reger) {
+    throw new ValidationError("VDR runtime did not open Reger.");
+  }
+  return reger as Reger;
+}
+
+function requireRegery(runtime: AgentRuntime): Regery {
+  if (!(runtime.vdr.rgy instanceof Regery)) {
+    throw new ValidationError("VDR runtime did not open Regery.");
+  }
+  return runtime.vdr.rgy;
+}
+
+function requireTevery(runtime: AgentRuntime): Tevery {
+  if (!(runtime.vdr.tvy instanceof Tevery)) {
+    throw new ValidationError("VDR runtime did not open Tevery.");
+  }
+  return runtime.vdr.tvy;
+}
+
+function requireVerifier(runtime: AgentRuntime): Verifier {
+  if (!(runtime.vdr.vry instanceof Verifier)) {
+    throw new ValidationError("VDR runtime did not open Verifier.");
+  }
+  return runtime.vdr.vry;
+}
+
+function cloneJsonObject(value: unknown): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/keri/src/did/webs/dids.ts
+++ b/packages/keri/src/did/webs/dids.ts
@@ -1,0 +1,273 @@
+/**
+ * DID parsing and canonicalization for `did:webs`, hosted `did:web`, and
+ * `did:keri` identifiers.
+ *
+ * Responsibilities:
+ * - keep encoded host/port handling deterministic
+ * - identify the terminal AID segment used by `did:webs`
+ * - derive artifact URLs without trusting hosted JSON
+ */
+import { ValidationError } from "../../core/errors.ts";
+
+export type DidMethod = "webs" | "web" | "keri";
+
+export interface DidQueryParts {
+  readonly did: string;
+  readonly query: string;
+  readonly fragment: string;
+}
+
+export interface ParsedDidWebs {
+  readonly kind: "webs" | "web";
+  readonly raw: string;
+  readonly canonical: string;
+  readonly method: "webs" | "web";
+  readonly host: string;
+  readonly encodedHost: string;
+  readonly path: readonly string[];
+  readonly aid: string;
+  readonly query: string;
+  readonly fragment: string;
+}
+
+export interface ParsedDidKeri {
+  readonly kind: "keri";
+  readonly raw: string;
+  readonly canonical: string;
+  readonly method: "keri";
+  readonly aid: string;
+  readonly query: string;
+  readonly fragment: string;
+}
+
+export type ParsedDid = ParsedDidWebs | ParsedDidKeri;
+
+export interface DidWebsArtifactUrls {
+  readonly didJson: string;
+  readonly keriCesr: string;
+}
+
+/** Split one DID into identifier, query, and fragment components. */
+export function splitDidQuery(input: string): DidQueryParts {
+  const hashIndex = input.indexOf("#");
+  const beforeFragment = hashIndex >= 0 ? input.slice(0, hashIndex) : input;
+  const fragment = hashIndex >= 0 ? input.slice(hashIndex + 1) : "";
+  const queryIndex = beforeFragment.indexOf("?");
+  return {
+    did: queryIndex >= 0 ? beforeFragment.slice(0, queryIndex) : beforeFragment,
+    query: queryIndex >= 0 ? beforeFragment.slice(queryIndex + 1) : "",
+    fragment,
+  };
+}
+
+/** Parse supported DID methods into a canonical descriptor. */
+export function parseDid(input: string): ParsedDid {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("did:")) {
+    throw new ValidationError(`Unsupported DID ${input}.`);
+  }
+  const parts = splitDidQuery(trimmed);
+  const [, method, ...methodParts] = parts.did.split(":");
+  switch (method) {
+    case "webs":
+    case "web":
+      return parseDidWebLike(trimmed, method, methodParts, parts);
+    case "keri":
+      return parseDidKeri(trimmed, methodParts, parts);
+    default:
+      throw new ValidationError(`Unsupported DID method ${method}.`);
+  }
+}
+
+/** Return true when a value looks like a supported or opaque DID string. */
+export function isDidString(value: string): boolean {
+  return /^did:[a-z0-9]+:/u.test(value);
+}
+
+/** Parse and require a `did:webs` or hosted `did:web` descriptor. */
+export function parseDidWebs(input: string): ParsedDidWebs {
+  const parsed = parseDid(input);
+  if (parsed.kind !== "webs" && parsed.kind !== "web") {
+    throw new ValidationError(`Expected did:webs or did:web, got ${input}.`);
+  }
+  return parsed;
+}
+
+/** Parse and require a `did:keri` descriptor. */
+export function parseDidKeriIdentifier(input: string): ParsedDidKeri {
+  const parsed = parseDid(input);
+  if (parsed.kind !== "keri") {
+    throw new ValidationError(`Expected did:keri, got ${input}.`);
+  }
+  return parsed;
+}
+
+/** Convert a canonical `did:webs` descriptor to the hosted `did:web` form. */
+export function toHostedDidWeb(input: string | ParsedDidWebs): string {
+  const parsed = typeof input === "string" ? parseDidWebs(input) : input;
+  return didWebLike("web", parsed.encodedHost, parsed.path, parsed.aid);
+}
+
+/** Convert a hosted `did:web` descriptor to canonical `did:webs` form. */
+export function toCanonicalDidWebs(input: string | ParsedDidWebs): string {
+  const parsed = typeof input === "string" ? parseDidWebs(input) : input;
+  return didWebLike("webs", parsed.encodedHost, parsed.path, parsed.aid);
+}
+
+/** Build artifact URLs for one canonical `did:webs` identifier. */
+export function didWebsArtifactUrls(
+  input: string | ParsedDidWebs,
+  options: { readonly scheme?: "https" | "http" } = {},
+): DidWebsArtifactUrls {
+  const parsed = typeof input === "string" ? parseDidWebs(input) : input;
+  const path = [...parsed.path, parsed.aid].map(encodeURIComponent).join("/");
+  const basePath = path.length > 0 ? `/${path}` : "";
+  const base = `${options.scheme ?? "https"}://${parsed.host}${basePath}`;
+  return {
+    didJson: `${base}/did.json${parsed.query ? `?${parsed.query}` : ""}`,
+    keriCesr: `${base}/keri.cesr`,
+  };
+}
+
+/**
+ * Build the canonical `did:webs` identifier represented by one HTTP artifact
+ * request.
+ */
+export function didWebsFromArtifactRequest(args: {
+  readonly host: string;
+  readonly didPath: readonly string[];
+  readonly aid: string;
+}): string {
+  const host = args.host.trim();
+  if (host.length === 0) {
+    throw new ValidationError("Artifact request is missing host.");
+  }
+  return didWebLike("webs", encodeHost(host), args.didPath, args.aid);
+}
+
+/**
+ * Normalize one hosted DID document by replacing its `did:web` form with the
+ * canonical `did:webs` form used for resolver comparison.
+ */
+export function normalizeHostedDidDocument<T>(
+  document: T,
+  canonicalDid: string,
+): T {
+  const canonical = parseDidWebs(canonicalDid);
+  const hostedDid = toHostedDidWeb(canonical);
+  return replaceStringValues(document, hostedDid, toCanonicalDidWebs(canonical));
+}
+
+function parseDidWebLike(
+  raw: string,
+  method: "webs" | "web",
+  methodParts: string[],
+  query: DidQueryParts,
+): ParsedDidWebs {
+  if (methodParts.length < 2) {
+    throw new ValidationError(`DID ${raw} must include host and AID segments.`);
+  }
+  const encodedHost = methodParts[0];
+  if (!encodedHost) {
+    throw new ValidationError(`DID ${raw} is missing host.`);
+  }
+  if (
+    !encodedHost.includes("%3A")
+    && !encodedHost.includes("%3a")
+    && methodParts[1] !== undefined
+    && /^\d+$/u.test(methodParts[1])
+  ) {
+    throw new ValidationError(
+      `DID ${raw} must encode host ports as %3A, not raw colon separators.`,
+    );
+  }
+  const aid = methodParts[methodParts.length - 1];
+  if (!aid) {
+    throw new ValidationError(`DID ${raw} is missing terminal AID segment.`);
+  }
+  const path = methodParts.slice(1, -1).map(decodeURIComponent);
+  const normalizedHost = decodeHost(encodedHost);
+  const canonical = didWebLike(method, encodeHost(normalizedHost), path, aid);
+  return {
+    kind: method,
+    raw,
+    canonical,
+    method,
+    host: normalizedHost,
+    encodedHost: encodeHost(normalizedHost),
+    path,
+    aid,
+    query: query.query,
+    fragment: query.fragment,
+  };
+}
+
+function parseDidKeri(
+  raw: string,
+  methodParts: string[],
+  query: DidQueryParts,
+): ParsedDidKeri {
+  const aid = methodParts[0];
+  if (!aid || methodParts.length !== 1) {
+    throw new ValidationError(`DID ${raw} must be did:keri:<aid>.`);
+  }
+  return {
+    kind: "keri",
+    raw,
+    canonical: `did:keri:${aid}`,
+    method: "keri",
+    aid,
+    query: query.query,
+    fragment: query.fragment,
+  };
+}
+
+function didWebLike(
+  method: "webs" | "web",
+  encodedHost: string,
+  path: readonly string[],
+  aid: string,
+): string {
+  return [
+    "did",
+    method,
+    encodedHost,
+    ...path.map(encodeURIComponent),
+    aid,
+  ].join(":");
+}
+
+function encodeHost(host: string): string {
+  return host.replaceAll(":", "%3A");
+}
+
+function decodeHost(encodedHost: string): string {
+  try {
+    return decodeURIComponent(encodedHost);
+  } catch (error) {
+    throw new ValidationError(
+      `Invalid DID host encoding: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function replaceStringValues<T>(
+  value: T,
+  from: string,
+  to: string,
+): T {
+  if (typeof value === "string") {
+    return value.replaceAll(from, to) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => replaceStringValues(item, from, to)) as T;
+  }
+  if (typeof value === "object" && value !== null) {
+    const result: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      result[key] = replaceStringValues(item, from, to);
+    }
+    return result as T;
+  }
+  return value;
+}

--- a/packages/keri/src/did/webs/documenting.ts
+++ b/packages/keri/src/did/webs/documenting.ts
@@ -1,0 +1,263 @@
+/**
+ * DID document projection from KERI/VDR runtime state.
+ *
+ * The document is a deterministic view over accepted key state, endpoint reply
+ * state, and active designated-alias credentials. Hosted artifacts may use
+ * `did:web`, but resolver comparison normalizes them back to `did:webs`.
+ */
+import type { AgentRuntime } from "../../app/agent-runtime.ts";
+import type { Habery } from "../../app/habbing.ts";
+import { ValidationError } from "../../core/errors.ts";
+import type { Kever } from "../../core/kever.ts";
+import { Roles } from "../../core/roles.ts";
+import { listActiveDesignatedAliasCredentials } from "./designated-aliases.ts";
+import { parseDid, parseDidWebs, toCanonicalDidWebs, toHostedDidWeb } from "./dids.ts";
+
+export interface DidResolutionResult {
+  readonly didDocument: DidDocument | null;
+  readonly didResolutionMetadata: Record<string, unknown>;
+  readonly didDocumentMetadata: Record<string, unknown>;
+}
+
+export interface DidDocument extends Record<string, unknown> {
+  readonly id: string;
+}
+
+export interface DidDocumentOptions {
+  readonly hosted?: boolean;
+  readonly metadata?: boolean;
+}
+
+/** Generate a DID document or DID Resolution Result from runtime state. */
+export function generateDidDocument(
+  runtime: AgentRuntime,
+  did: string,
+  options: DidDocumentOptions = {},
+): DidDocument | DidResolutionResult {
+  const document = generateBareDidDocument(runtime, did, options);
+  if (!options.metadata) {
+    return document;
+  }
+  return {
+    didDocument: document,
+    didResolutionMetadata: {
+      contentType: "application/did+json",
+    },
+    didDocumentMetadata: {},
+  };
+}
+
+/** Generate only the DID document body from runtime state. */
+export function generateBareDidDocument(
+  runtime: AgentRuntime,
+  did: string,
+  options: DidDocumentOptions = {},
+): DidDocument {
+  const parsed = parseDid(did);
+  const aid = parsed.aid;
+  const kever = runtime.hby.db.getKever(aid, { refresh: true });
+  if (!kever) {
+    throw new ValidationError(`No accepted key state for ${aid}.`);
+  }
+  const documentDid = parsed.kind === "webs" || parsed.kind === "web"
+    ? options.hosted
+      ? toHostedDidWeb(parseDidWebs(did))
+      : toCanonicalDidWebs(parseDidWebs(did))
+    : parsed.canonical;
+  const methodEntries = verificationMethods(documentDid, kever);
+  methodEntries.push(...thresholdVerificationMethods(documentDid, kever, methodEntries.map((entry) => entry.id)));
+  const services = serviceEntries(runtime.hby, aid);
+  const aliases = listActiveDesignatedAliasCredentials(runtime, aid)
+    .flatMap((item) => item.aliases)
+    .sort();
+  return pruneEmpty({
+    id: documentDid,
+    verificationMethod: methodEntries,
+    service: services,
+    alsoKnownAs: [...new Set(aliases)],
+  }) as DidDocument;
+}
+
+/** Format one successful resolution result. */
+export function didResolutionResult(
+  document: DidDocument,
+  contentType = "application/did+json",
+): DidResolutionResult {
+  return {
+    didDocument: document,
+    didResolutionMetadata: { contentType },
+    didDocumentMetadata: {},
+  };
+}
+
+/** Format one failed resolution result. */
+export function didResolutionError(
+  error: string,
+  message: string,
+): DidResolutionResult {
+  return {
+    didDocument: null,
+    didResolutionMetadata: { error, message },
+    didDocumentMetadata: {},
+  };
+}
+
+function verificationMethods(
+  did: string,
+  kever: Kever,
+): Array<Record<string, unknown> & { id: string }> {
+  return kever.verfers.map((verfer) => ({
+    id: `#${verfer.qb64}`,
+    type: "JsonWebKey",
+    controller: did,
+    publicKeyJwk: {
+      kid: verfer.qb64,
+      kty: "OKP",
+      crv: "Ed25519",
+      x: base64Url(verfer.raw),
+    },
+  }));
+}
+
+function thresholdVerificationMethods(
+  did: string,
+  kever: Kever,
+  methodIds: readonly string[],
+): Array<Record<string, unknown> & { id: string }> {
+  const tholder = kever.tholder;
+  if (!tholder || methodIds.length === 0) {
+    return [];
+  }
+  if (!tholder.weighted && (tholder.num ?? 1n) <= 1n) {
+    return [];
+  }
+  if (!tholder.weighted) {
+    return [{
+      id: `#${kever.prefixer.qb64}`,
+      type: "ConditionalProof2022",
+      controller: did,
+      threshold: Number(tholder.num ?? 1n),
+      conditionThreshold: [...methodIds],
+    }];
+  }
+  return [{
+    id: `#${kever.prefixer.qb64}`,
+    type: "ConditionalProof2022",
+    controller: did,
+    threshold: tholder.sith,
+    conditionWeightedThreshold: weightedConditions(tholder.sith, methodIds),
+  }];
+}
+
+function serviceEntries(
+  hby: Habery,
+  aid: string,
+): Array<Record<string, unknown>> {
+  const entries: Array<Record<string, unknown>> = [];
+  const ends = endpointUrls(hby, aid);
+  for (const [role, endpoints] of Object.entries(ends).sort()) {
+    for (const [eid, urls] of Object.entries(endpoints).sort()) {
+      const endpoint = serviceEndpoint(urls);
+      if (!endpoint) {
+        continue;
+      }
+      entries.push({
+        id: `#${eid}/${role}`,
+        type: role,
+        serviceEndpoint: endpoint,
+      });
+    }
+  }
+  return entries;
+}
+
+function endpointUrls(
+  hby: Habery,
+  aid: string,
+): Record<string, Record<string, Record<string, string>>> {
+  const ends: Record<string, Record<string, Record<string, string>>> = {};
+  for (
+    const [keys, end] of hby.db.ends.getTopItemIter([aid], { topive: true })
+  ) {
+    const role = keys[1];
+    const eid = keys[2];
+    if (!role || !eid || !(end.allowed || end.enabled)) {
+      continue;
+    }
+    const urls = fetchUrls(hby, eid);
+    if (Object.keys(urls).length === 0) {
+      continue;
+    }
+    ends[role] ??= {};
+    ends[role][eid] = urls;
+  }
+
+  const kever = hby.db.getKever(aid, { refresh: true });
+  if (kever?.wits && kever.wits.length > 0) {
+    const witnessUrls: Record<string, Record<string, string>> = {};
+    for (const eid of [...kever.wits].sort()) {
+      const urls = fetchUrls(hby, eid);
+      if (Object.keys(urls).length > 0) {
+        witnessUrls[eid] = urls;
+      }
+    }
+    if (Object.keys(witnessUrls).length > 0) {
+      ends[Roles.witness] = witnessUrls;
+    }
+  }
+  return ends;
+}
+
+function fetchUrls(hby: Habery, eid: string): Record<string, string> {
+  const urls: Record<string, string> = {};
+  for (
+    const [path, loc] of hby.db.locs.getTopItemIter([eid], { topive: true })
+  ) {
+    const scheme = path[1];
+    if (scheme && loc.url) {
+      urls[scheme] = loc.url;
+    }
+  }
+  return urls;
+}
+
+function serviceEndpoint(urls: Record<string, string>): Record<string, string> | null {
+  const sorted = Object.entries(urls).sort();
+  if (sorted.length === 0) {
+    return null;
+  }
+  return Object.fromEntries(sorted);
+}
+
+function pruneEmpty(value: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (Array.isArray(item) && item.length === 0) {
+      continue;
+    }
+    result[key] = item;
+  }
+  return result;
+}
+
+function weightedConditions(
+  threshold: unknown,
+  methodIds: readonly string[],
+): Array<Record<string, unknown>> {
+  if (!Array.isArray(threshold) || threshold.length === 0) {
+    return methodIds.map((id) => ({ condition: id, weight: 1 }));
+  }
+  const weights = Array.isArray(threshold[0]) ? threshold[0] : threshold;
+  return methodIds.map((id, index) => ({
+    condition: id,
+    weight: weights[index] ?? 1,
+  }));
+}
+
+function base64Url(raw: Uint8Array): string {
+  let text = "";
+  for (const byte of raw) {
+    text += String.fromCharCode(byte);
+  }
+  return btoa(text).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}

--- a/packages/keri/src/did/webs/resolving.ts
+++ b/packages/keri/src/did/webs/resolving.ts
@@ -1,0 +1,172 @@
+/**
+ * Verified `did:webs` resolution.
+ *
+ * Resolution succeeds only when hosted `did.json` matches the DID document
+ * regenerated from the fetched `keri.cesr` KERI/VDR stream.
+ */
+import { action, type Operation } from "effection";
+import type { AgentRuntime } from "../../app/agent-runtime.ts";
+import { settleRuntimeIngress } from "../../app/agent-runtime.ts";
+import { fetchResponseHandle } from "../../app/httping.ts";
+import { ValidationError } from "../../core/errors.ts";
+import { pinDesignatedAliasesSchema } from "./designated-aliases.ts";
+import { didWebsArtifactUrls, normalizeHostedDidDocument, parseDidWebs } from "./dids.ts";
+import {
+  type DidDocument,
+  type DidResolutionResult,
+  didResolutionResult,
+  generateBareDidDocument,
+} from "./documenting.ts";
+
+export interface ResolveDidWebsOptions {
+  readonly did: string;
+  readonly metadata?: boolean;
+  readonly insecureHttp?: boolean;
+}
+
+export interface ResolveDidWebsResult {
+  readonly did: string;
+  readonly document: DidDocument;
+  readonly resolution: DidResolutionResult;
+}
+
+/** Resolve one `did:webs` by fetching and verifying hosted artifacts. */
+export function* resolveDidWebs(
+  runtime: AgentRuntime,
+  options: ResolveDidWebsOptions,
+): Operation<ResolveDidWebsResult> {
+  const parsed = parseDidWebs(options.did);
+  const urls = didWebsArtifactUrls(parsed, { scheme: "https" });
+  const fallbackUrls = didWebsArtifactUrls(parsed, { scheme: "http" });
+  pinDesignatedAliasesSchema(runtime);
+  const cesr = yield* fetchBytesWithFallback(
+    urls.keriCesr,
+    fallbackUrls.keriCesr,
+    options.insecureHttp ?? false,
+  );
+  settleRuntimeIngress(runtime, [cesr], { local: false });
+  runtime.reactor.processEscrowsOnce();
+  const expected = generateBareDidDocument(runtime, parsed.canonical);
+  const hosted = yield* fetchJsonWithFallback(
+    urls.didJson,
+    fallbackUrls.didJson,
+    options.insecureHttp ?? false,
+  );
+  const hostedDocument = hostedDidDocument(hosted);
+  const normalized = normalizeHostedDidDocument(hostedDocument, parsed.canonical);
+  assertSameDocument(expected, normalized);
+  const resolution = didResolutionResult(expected);
+  return {
+    did: parsed.canonical,
+    document: expected,
+    resolution,
+  };
+}
+
+function* fetchBytes(url: string): Operation<Uint8Array> {
+  const { response } = yield* fetchResponseHandle(url);
+  if (!response.ok) {
+    yield* closeBody(response);
+    throw new ValidationError(`Unable to fetch ${url}: HTTP ${response.status}.`);
+  }
+  return yield* readResponseBytes(response);
+}
+
+function* fetchBytesWithFallback(
+  httpsUrl: string,
+  httpUrl: string,
+  preferHttp: boolean,
+): Operation<Uint8Array> {
+  const urls = preferHttp ? [httpUrl, httpsUrl] : [httpsUrl, httpUrl];
+  let lastError: unknown;
+  for (const url of [...new Set(urls)]) {
+    try {
+      return yield* fetchBytes(url);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new ValidationError(String(lastError));
+}
+
+function* fetchJsonWithFallback(
+  httpsUrl: string,
+  httpUrl: string,
+  preferHttp: boolean,
+): Operation<unknown> {
+  const bytes = yield* fetchBytesWithFallback(httpsUrl, httpUrl, preferHttp);
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch (error) {
+    throw new ValidationError(
+      `Unable to parse DID JSON from ${preferHttp ? httpUrl : httpsUrl}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+function* readResponseBytes(response: Response): Operation<Uint8Array> {
+  return yield* action<Uint8Array>((resolve, reject) => {
+    response.arrayBuffer()
+      .then((buffer) => resolve(new Uint8Array(buffer)))
+      .catch(reject);
+    return () => {};
+  });
+}
+
+function* closeBody(response: Response): Operation<void> {
+  if (!response.body) {
+    return;
+  }
+  yield* action<void>((resolve) => {
+    void response.body!.cancel().finally(() => resolve(undefined));
+    return () => {};
+  });
+}
+
+function hostedDidDocument(value: unknown): DidDocument {
+  if (!isRecord(value)) {
+    throw new ValidationError("Hosted did.json must be a JSON object.");
+  }
+  const maybeDocument = isRecord(value.didDocument) ? value.didDocument : value;
+  if (typeof maybeDocument.id !== "string") {
+    throw new ValidationError("Hosted DID document is missing id.");
+  }
+  return maybeDocument as DidDocument;
+}
+
+function assertSameDocument(
+  expected: DidDocument,
+  actual: DidDocument,
+): void {
+  const expectedJson = canonicalJson(expected);
+  const actualJson = canonicalJson(actual);
+  if (expectedJson !== actualJson) {
+    throw new ValidationError(
+      `Hosted did.json does not match KERI/VDR state. Expected ${expectedJson}; got ${actualJson}.`,
+    );
+  }
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJson);
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, sortJson(item)]),
+    );
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/keri/src/runtime/index.ts
+++ b/packages/keri/src/runtime/index.ts
@@ -64,6 +64,7 @@ export * from "../core/roles.ts";
 export * from "../core/schemes.ts";
 export * from "../core/scheming.ts";
 export * from "../db/verifier-cueing.ts";
+export * from "../did/index.ts";
 export * from "../time/mod.ts";
 export * from "../vdr/credentialing.ts";
 export * from "../vdr/eventing.ts";

--- a/packages/keri/test/integration/app/interop-did-webs-resolver-matrix.test.ts
+++ b/packages/keri/test/integration/app/interop-did-webs-resolver-matrix.test.ts
@@ -1,0 +1,714 @@
+// @file-test-lane interop-did-webs
+
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert";
+import {
+  createInteropContext,
+  DID_WEBS_RESOLVER_INTEROP_COMMIT,
+  ensurePinnedDidWebsResolver,
+  extractPrefix,
+  type InteropContext,
+  type KeriPyWitnessNode,
+  randomPort,
+  requireSuccess,
+  runCmdWithTimeout,
+  runTufaWithTimeout,
+  spawnChild,
+  type SpawnedChild,
+  startKeriPyWitnessDemoHarness,
+  stopChild,
+  waitForHealth,
+} from "./interop-test-helpers.ts";
+
+const DA_SCHEMA_SAID = "EN6Oh5XSD5_q2Hgu-aqpdfbVepdpYpFlgz6zvJL5b_r5";
+const DA_REGISTRY_NAME = "did:webs_designated_aliases";
+const DID_PATH = "dws";
+
+interface TufaController {
+  readonly name: string;
+  readonly alias: string;
+  readonly headDirPath: string;
+  readonly aid: string;
+  readonly witness: KeriPyWitnessNode;
+}
+
+interface PythonController {
+  readonly name: string;
+  readonly base: string;
+  readonly alias: string;
+  readonly aid: string;
+  readonly witness: KeriPyWitnessNode;
+}
+
+function siblingCommand(command: string, name: string): string {
+  return `${command.slice(0, command.lastIndexOf("/"))}/${name}`;
+}
+
+function didFor(port: number, aid: string): string {
+  return `did:webs:127.0.0.1%3A${port}:${DID_PATH}:${aid}`;
+}
+
+function didKeri(aid: string): string {
+  return `did:keri:${aid}`;
+}
+
+async function initTufaStore(
+  ctx: InteropContext,
+  name: string,
+  headDirPath: string,
+): Promise<void> {
+  await requireSuccess(
+    `${name} init`,
+    runTufaWithTimeout(
+      ["init", "--name", name, "--head-dir", headDirPath, "--nopasscode"],
+      ctx.env,
+      ctx.repoRoot,
+      20_000,
+    ),
+  );
+}
+
+async function resolveWitnessesForTufa(
+  ctx: InteropContext,
+  name: string,
+  headDirPath: string,
+  witness: KeriPyWitnessNode,
+): Promise<void> {
+  for (const url of [witness.controllerOobi, witness.witnessOobi]) {
+    await requireSuccess(
+      `tufa resolve witness ${url}`,
+      runTufaWithTimeout(
+        [
+          "oobi",
+          "resolve",
+          "--name",
+          name,
+          "--head-dir",
+          headDirPath,
+          "--url",
+          url,
+          "--oobi-alias",
+          witness.alias,
+        ],
+        ctx.env,
+        ctx.repoRoot,
+        20_000,
+      ),
+    );
+  }
+}
+
+async function inceptTufaController(
+  ctx: InteropContext,
+  witness: KeriPyWitnessNode,
+): Promise<TufaController> {
+  const headDirPath = await Deno.makeTempDir({ prefix: "did-webs-tufa-" });
+  const name = `dws-tufa-${crypto.randomUUID().slice(0, 8)}`;
+  const alias = "controller";
+  await initTufaStore(ctx, name, headDirPath);
+  await resolveWitnessesForTufa(ctx, name, headDirPath, witness);
+  const incepted = await requireSuccess(
+    "tufa witnessed incept",
+    runTufaWithTimeout(
+      [
+        "incept",
+        "--name",
+        name,
+        "--head-dir",
+        headDirPath,
+        "--alias",
+        alias,
+        "--transferable",
+        "--icount",
+        "1",
+        "--isith",
+        "1",
+        "--ncount",
+        "1",
+        "--nsith",
+        "1",
+        "--toad",
+        "1",
+        "--receipt-endpoint",
+        "--wits",
+        witness.pre,
+      ],
+      ctx.env,
+      ctx.repoRoot,
+      30_000,
+    ),
+  );
+  return { name, alias, headDirPath, aid: extractPrefix(incepted.stdout), witness };
+}
+
+async function bindTufaDesignatedAliases(
+  ctx: InteropContext,
+  controller: TufaController,
+  did: string,
+): Promise<void> {
+  await requireSuccess(
+    "tufa dws bind designated aliases",
+    runTufaWithTimeout(
+      [
+        "dws",
+        "bind",
+        "--name",
+        controller.name,
+        "--head-dir",
+        controller.headDirPath,
+        "--alias",
+        controller.alias,
+        "--did",
+        didKeri(controller.aid),
+        "--did",
+        did,
+      ],
+      ctx.env,
+      ctx.repoRoot,
+      30_000,
+    ),
+  );
+}
+
+async function generateTufaArtifacts(
+  ctx: InteropContext,
+  controller: TufaController,
+  did: string,
+  webRoot: string,
+): Promise<void> {
+  await requireSuccess(
+    "tufa dws generate artifacts",
+    runTufaWithTimeout(
+      [
+        "dws",
+        "generate",
+        "--name",
+        controller.name,
+        "--head-dir",
+        controller.headDirPath,
+        "--alias",
+        controller.alias,
+        "--did",
+        did,
+        "--output-dir",
+        webRoot,
+      ],
+      ctx.env,
+      ctx.repoRoot,
+      30_000,
+    ),
+  );
+}
+
+async function startTufaStaticResolver(
+  ctx: InteropContext,
+  headDirPath: string,
+  webRoot: string,
+  port: number,
+): Promise<SpawnedChild> {
+  const name = `dws-static-${crypto.randomUUID().slice(0, 8)}`;
+  await initTufaStore(ctx, name, headDirPath);
+  const child = spawnChild(
+    Deno.execPath(),
+    [
+      "run",
+      "--allow-all",
+      "--unstable-ffi",
+      "packages/tufa/mod.ts",
+      "dws",
+      "resolver",
+      "--name",
+      name,
+      "--head-dir",
+      headDirPath,
+      "--port",
+      String(port),
+      "--listen-host",
+      "127.0.0.1",
+      "--static-files-dir",
+      webRoot,
+      "--did-path",
+      DID_PATH,
+    ],
+    ctx.env,
+    ctx.repoRoot,
+  );
+  await waitForHealth(port);
+  return child;
+}
+
+async function initKliStore(
+  kliCommand: string,
+  env: Record<string, string>,
+  name: string,
+  base: string,
+  config?: { readonly dir: string; readonly file: string },
+): Promise<string> {
+  const args = ["init", "--name", name, "--base", base, "--nopasscode"];
+  if (config) {
+    args.push("--config-dir", config.dir, "--config-file", config.file);
+  }
+  const initialized = await requireSuccess(
+    `${name} init`,
+    runCmdWithTimeout(
+      kliCommand,
+      args,
+      env,
+      config ? 60_000 : 20_000,
+    ),
+  );
+  return `${initialized.stdout}\n${initialized.stderr}`;
+}
+
+async function inceptPythonController(
+  ctx: InteropContext,
+  kliCommand: string,
+  witness: KeriPyWitnessNode,
+  didWebsResolverRoot: string,
+): Promise<PythonController> {
+  const name = `dws-python-${crypto.randomUUID().slice(0, 8)}`;
+  const base = `dws-python-${crypto.randomUUID().slice(0, 8)}`;
+  const alias = "controller";
+  const initOutput = await initKliStore(kliCommand, ctx.env, name, base, {
+    dir: `${didWebsResolverRoot}/local/config/controller`,
+    file: "dws-controller",
+  });
+  assertKliInitLoadedWitnessOobi(initOutput, witness);
+  const incepted = await requireSuccess(
+    "kli witnessed incept",
+    runCmdWithTimeout(
+      kliCommand,
+      [
+        "incept",
+        "--name",
+        name,
+        "--base",
+        base,
+        "--alias",
+        alias,
+        "--file",
+        `${didWebsResolverRoot}/local/config/controller/incept-with-wan-wit.json`,
+      ],
+      ctx.env,
+      30_000,
+    ),
+  );
+  await requireSuccess(
+    "kli witness submit",
+    runCmdWithTimeout(
+      kliCommand,
+      [
+        "witness",
+        "submit",
+        "--name",
+        name,
+        "--base",
+        base,
+        "--alias",
+        alias,
+        "--receipt-endpoint",
+      ],
+      ctx.env,
+      30_000,
+    ),
+  );
+  return { name, base, alias, aid: extractPrefix(incepted.stdout), witness };
+}
+
+function assertKliInitLoadedWitnessOobi(
+  initOutput: string,
+  witness: KeriPyWitnessNode,
+): void {
+  if (
+    !initOutput.includes(witness.controllerOobi)
+    || !initOutput.includes("succeeded")
+  ) {
+    throw new Error(
+      `Python controller init did not resolve configured witness controller OOBI before inception.\n`
+        + `Expected ${witness.controllerOobi} to succeed.\n`
+        + `kli init output:\n${initOutput.trim() || "<empty>"}`,
+    );
+  }
+}
+
+async function issuePythonDesignatedAliases(
+  tooling: { readonly root: string; readonly pythonCommand: string },
+  kliCommand: string,
+  env: Record<string, string>,
+  controller: PythonController,
+  did: string,
+): Promise<void> {
+  await requireSuccess(
+    "pin Python DA schema resource",
+    runCmdWithTimeout(
+      tooling.pythonCommand,
+      [
+        "-c",
+        [
+          "import sys",
+          "from dws.core import habs, schemaing",
+          "name, base = sys.argv[1], sys.argv[2]",
+          "hby, _ = habs.get_habery_and_doer(name, base, None, None)",
+          "try:",
+          "    schemaing.pin_designated_aliases_schema(hby)",
+          "finally:",
+          "    hby.close(clear=False)",
+        ].join("\n"),
+        controller.name,
+        controller.base,
+      ],
+      env,
+      20_000,
+    ),
+  );
+  await assertPythonWitnessEndpointKnown(kliCommand, env, controller);
+  await requireSuccess(
+    "kli DA registry incept",
+    runCmdWithTimeout(
+      kliCommand,
+      [
+        "vc",
+        "registry",
+        "incept",
+        "--name",
+        controller.name,
+        "--base",
+        controller.base,
+        "--alias",
+        controller.alias,
+        "--registry-name",
+        DA_REGISTRY_NAME,
+      ],
+      env,
+      45_000,
+    ),
+  );
+  await submitPythonWitnessReceipts(kliCommand, env, controller);
+
+  const dataPath = await Deno.makeTempFile({ prefix: "did-webs-da-", suffix: ".json" });
+  const time = await requireSuccess(
+    "kli time",
+    runCmdWithTimeout(kliCommand, ["time"], env, 10_000),
+  );
+  const ids = [didKeri(controller.aid), did].sort();
+  await Deno.writeTextFile(
+    dataPath,
+    `${
+      JSON.stringify(
+        {
+          d: "",
+          dt: time.stdout.trim(),
+          ids,
+        },
+        null,
+        2,
+      )
+    }\n`,
+  );
+  await requireSuccess(
+    "kli saidify DA data",
+    runCmdWithTimeout(kliCommand, ["saidify", "--file", dataPath], env, 20_000),
+  );
+  await requireSuccess(
+    "kli DA credential create",
+    runCmdWithTimeout(
+      kliCommand,
+      [
+        "vc",
+        "create",
+        "--name",
+        controller.name,
+        "--base",
+        controller.base,
+        "--alias",
+        controller.alias,
+        "--registry-name",
+        DA_REGISTRY_NAME,
+        "--schema",
+        DA_SCHEMA_SAID,
+        "--data",
+        `@${dataPath}`,
+        "--rules",
+        `@${tooling.root}/local/schema/rules/desig-aliases-public-schema-rules.json`,
+      ],
+      env,
+      60_000,
+    ),
+  );
+  await submitPythonWitnessReceipts(kliCommand, env, controller);
+  await Deno.remove(dataPath).catch(() => undefined);
+}
+
+async function assertPythonWitnessEndpointKnown(
+  kliCommand: string,
+  env: Record<string, string>,
+  controller: PythonController,
+): Promise<void> {
+  const listed = await requireSuccess(
+    "kli list witness endpoints",
+    runCmdWithTimeout(
+      kliCommand,
+      [
+        "ends",
+        "list",
+        "--name",
+        controller.name,
+        "--base",
+        controller.base,
+        "--alias",
+        controller.alias,
+        "--aid",
+        controller.witness.pre,
+      ],
+      env,
+      10_000,
+    ),
+  );
+  const output = `${listed.stdout}\n${listed.stderr}`.trim();
+  if (!output.includes("http") || !output.includes(String(controller.witness.httpPort))) {
+    throw new Error(
+      `Python controller store is missing witness endpoint material for ${controller.witness.pre}.\n`
+        + `Expected HTTP endpoint on port ${controller.witness.httpPort} before DA registry inception.\n`
+        + `kli ends list output:\n${output || "<empty>"}`,
+    );
+  }
+}
+
+async function submitPythonWitnessReceipts(
+  kliCommand: string,
+  env: Record<string, string>,
+  controller: PythonController,
+): Promise<void> {
+  await requireSuccess(
+    "kli witness submit",
+    runCmdWithTimeout(
+      kliCommand,
+      [
+        "witness",
+        "submit",
+        "--name",
+        controller.name,
+        "--base",
+        controller.base,
+        "--alias",
+        controller.alias,
+        "--receipt-endpoint",
+      ],
+      env,
+      30_000,
+    ),
+  );
+}
+
+async function generatePythonArtifacts(
+  dwsCommand: string,
+  env: Record<string, string>,
+  controller: PythonController,
+  did: string,
+  webRoot: string,
+): Promise<void> {
+  await requireSuccess(
+    "python dws generate artifacts",
+    runCmdWithTimeout(
+      dwsCommand,
+      [
+        "did",
+        "webs",
+        "generate",
+        "--name",
+        controller.name,
+        "--base",
+        controller.base,
+        "--did",
+        did,
+        "--output-dir",
+        `${webRoot}/${DID_PATH}`,
+      ],
+      env,
+      60_000,
+    ),
+  );
+}
+
+async function assertTufaResolvesDidWebs(
+  ctx: InteropContext,
+  did: string,
+): Promise<void> {
+  const headDirPath = await Deno.makeTempDir({ prefix: "did-webs-tufa-resolver-" });
+  const name = `dws-tufa-resolver-${crypto.randomUUID().slice(0, 8)}`;
+  await initTufaStore(ctx, name, headDirPath);
+  const resolved = await requireSuccess(
+    "tufa dws resolve",
+    runTufaWithTimeout(
+      ["dws", "resolve", "--name", name, "--head-dir", headDirPath, "--did", did],
+      ctx.env,
+      ctx.repoRoot,
+      60_000,
+    ),
+  );
+  assertStringIncludes(resolved.stdout, `"id": "${did}"`);
+}
+
+async function assertPythonResolvesDidWebs(
+  dwsCommand: string,
+  kliCommand: string,
+  env: Record<string, string>,
+  did: string,
+): Promise<void> {
+  const name = `dws-python-resolver-${crypto.randomUUID().slice(0, 8)}`;
+  const base = `dws-python-resolver-${crypto.randomUUID().slice(0, 8)}`;
+  await initKliStore(kliCommand, env, name, base);
+  const resolved = await requireSuccess(
+    "python dws resolve",
+    runCmdWithTimeout(
+      dwsCommand,
+      ["did", "webs", "resolve", "--name", name, "--base", base, "--did", did, "--verbose"],
+      env,
+      60_000,
+    ),
+  );
+  assertStringIncludes(resolved.stdout, `did:webs verification success for ${did}`);
+}
+
+async function assertPythonResolvesDidKeri(
+  dwsCommand: string,
+  kliCommand: string,
+  env: Record<string, string>,
+  did: string,
+  oobi: string,
+): Promise<void> {
+  const name = `dws-python-dkr-${crypto.randomUUID().slice(0, 8)}`;
+  const base = `dws-python-dkr-${crypto.randomUUID().slice(0, 8)}`;
+  await initKliStore(kliCommand, env, name, base);
+  const resolved = await requireSuccess(
+    "python dws did:keri resolve",
+    runCmdWithTimeout(
+      dwsCommand,
+      ["did", "keri", "resolve", "--name", name, "--base", base, "--did", did, "--oobi", oobi, "--verbose"],
+      env,
+      60_000,
+    ),
+  );
+  assertStringIncludes(resolved.stdout, `did:keri verification success for ${did}`);
+}
+
+async function assertTufaResolvesDidKeri(
+  ctx: InteropContext,
+  did: string,
+  oobi: string,
+): Promise<void> {
+  const headDirPath = await Deno.makeTempDir({ prefix: "did-keri-tufa-resolver-" });
+  const name = `dkr-tufa-resolver-${crypto.randomUUID().slice(0, 8)}`;
+  await initTufaStore(ctx, name, headDirPath);
+  const resolved = await requireSuccess(
+    "tufa dkr resolve",
+    runTufaWithTimeout(
+      ["dkr", "resolve", "--name", name, "--head-dir", headDirPath, "--did", did, "--oobi", oobi],
+      ctx.env,
+      ctx.repoRoot,
+      60_000,
+    ),
+  );
+  assertStringIncludes(resolved.stdout, `"id": "${did}"`);
+}
+
+Deno.test("interop/did-webs-resolver - Tufa-generated witnessed did:webs artifacts resolve with Python did-webs-resolver", async () => {
+  const ctx = await createInteropContext();
+  const tooling = await ensurePinnedDidWebsResolver(ctx.env);
+  const pyKli = siblingCommand(tooling.dwsCommand, "kli");
+  const harness = await startKeriPyWitnessDemoHarness(ctx, {
+    kliCommand: pyKli,
+    useBase: false,
+  });
+  let staticServer: SpawnedChild | undefined;
+  try {
+    const controller = await inceptTufaController(ctx, harness.node("wan"));
+    const port = randomPort();
+    const webRoot = await Deno.makeTempDir({ prefix: "did-webs-tufa-web-" });
+    const did = didFor(port, controller.aid);
+    await bindTufaDesignatedAliases(ctx, controller, did);
+    await generateTufaArtifacts(ctx, controller, did, webRoot);
+    staticServer = await startTufaStaticResolver(ctx, controller.headDirPath, webRoot, port);
+    await assertPythonResolvesDidWebs(tooling.dwsCommand, pyKli, ctx.env, did);
+  } finally {
+    if (staticServer) {
+      await stopChild(staticServer);
+    }
+    await harness.close();
+  }
+});
+
+Deno.test("interop/did-webs-resolver - Python-generated witnessed did:webs artifacts resolve with Tufa", async () => {
+  const ctx = await createInteropContext();
+  const tooling = await ensurePinnedDidWebsResolver(ctx.env);
+  const pyKli = siblingCommand(tooling.dwsCommand, "kli");
+  const harness = await startKeriPyWitnessDemoHarness(ctx, {
+    kliCommand: pyKli,
+    useBase: false,
+  });
+  let staticServer: SpawnedChild | undefined;
+  try {
+    const controller = await inceptPythonController(ctx, pyKli, harness.node("wan"), tooling.root);
+    const port = randomPort();
+    const webRoot = await Deno.makeTempDir({ prefix: "did-webs-python-web-" });
+    const did = didFor(port, controller.aid);
+    await issuePythonDesignatedAliases(tooling, pyKli, ctx.env, controller, did);
+    await generatePythonArtifacts(tooling.dwsCommand, ctx.env, controller, did, webRoot);
+    const staticHeadDir = await Deno.makeTempDir({ prefix: "did-webs-python-static-" });
+    staticServer = await startTufaStaticResolver(ctx, staticHeadDir, webRoot, port);
+    await assertTufaResolvesDidWebs(ctx, did);
+  } finally {
+    if (staticServer) {
+      await stopChild(staticServer);
+    }
+    await harness.close();
+  }
+});
+
+Deno.test("interop/did-webs-resolver - Tufa witnessed did:keri AID resolves with Python did-webs-resolver", async () => {
+  const ctx = await createInteropContext();
+  const tooling = await ensurePinnedDidWebsResolver(ctx.env);
+  const pyKli = siblingCommand(tooling.dwsCommand, "kli");
+  const harness = await startKeriPyWitnessDemoHarness(ctx, {
+    kliCommand: pyKli,
+    useBase: false,
+  });
+  try {
+    const controller = await inceptTufaController(ctx, harness.node("wan"));
+    await assertPythonResolvesDidKeri(
+      tooling.dwsCommand,
+      pyKli,
+      ctx.env,
+      didKeri(controller.aid),
+      `http://127.0.0.1:${controller.witness.httpPort}/oobi/${controller.aid}/witness/${controller.witness.pre}`,
+    );
+  } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("interop/did-webs-resolver - Python witnessed did:keri AID resolves with Tufa", async () => {
+  const ctx = await createInteropContext();
+  const tooling = await ensurePinnedDidWebsResolver(ctx.env);
+  const pyKli = siblingCommand(tooling.dwsCommand, "kli");
+  const harness = await startKeriPyWitnessDemoHarness(ctx, {
+    kliCommand: pyKli,
+    useBase: false,
+  });
+  try {
+    const controller = await inceptPythonController(ctx, pyKli, harness.node("wan"), tooling.root);
+    await assertTufaResolvesDidKeri(
+      ctx,
+      didKeri(controller.aid),
+      `http://127.0.0.1:${controller.witness.httpPort}/oobi/${controller.aid}/witness/${controller.witness.pre}`,
+    );
+  } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("interop/did-webs-resolver - pinned Python resolver SHA is explicit", () => {
+  assertEquals(
+    DID_WEBS_RESOLVER_INTEROP_COMMIT,
+    "8395277f32b37129fa6ef734c9f3902bb6cbbcbc",
+  );
+});

--- a/packages/keri/test/integration/app/interop-test-helpers.ts
+++ b/packages/keri/test/integration/app/interop-test-helpers.ts
@@ -75,6 +75,11 @@ export interface TufaWitnessHarnessOptions {
   headDirPath?: string;
 }
 
+export interface KeriPyWitnessDemoHarnessOptions {
+  readonly kliCommand?: string;
+  readonly useBase?: boolean;
+}
+
 /** Default KERIpy witness aliases shipped in the reference config set. */
 const DEFAULT_KERIPY_WITNESS_ALIASES = [
   "wan",
@@ -92,6 +97,51 @@ const DEFAULT_TUFA_WITNESS_ALIASES = [
   "twes",
   "twit",
 ] as const;
+
+const KERIPY_DEMO_WITNESS_NODES: readonly KeriPyWitnessNode[] = [
+  {
+    alias: "wan",
+    name: "wan",
+    pre: "BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha",
+    httpPort: 5642,
+    tcpPort: 5632,
+    httpOrigin: "http://127.0.0.1:5642",
+    tcpUrl: "tcp://127.0.0.1:5632",
+    controllerOobi: "http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller",
+    witnessOobi:
+      "http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha",
+    mailboxOobi:
+      "http://127.0.0.1:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/mailbox/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha",
+  },
+  {
+    alias: "wil",
+    name: "wil",
+    pre: "BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM",
+    httpPort: 5643,
+    tcpPort: 5633,
+    httpOrigin: "http://127.0.0.1:5643",
+    tcpUrl: "tcp://127.0.0.1:5633",
+    controllerOobi: "http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller",
+    witnessOobi:
+      "http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/witness/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM",
+    mailboxOobi:
+      "http://127.0.0.1:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/mailbox/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM",
+  },
+  {
+    alias: "wes",
+    name: "wes",
+    pre: "BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX",
+    httpPort: 5644,
+    tcpPort: 5634,
+    httpOrigin: "http://127.0.0.1:5644",
+    tcpUrl: "tcp://127.0.0.1:5634",
+    controllerOobi: "http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller",
+    witnessOobi:
+      "http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/witness/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX",
+    mailboxOobi:
+      "http://127.0.0.1:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/mailbox/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX",
+  },
+];
 
 /** Pinned KERIpy fork commit used by all KLI interop tests. */
 export const KERIPY_INTEROP_COMMIT = "98b88cf73a746813a8719f05264400467a474c05";
@@ -122,6 +172,18 @@ const INTEROP_VERIFIER_FIXTURE_FILES = [
   "src/interop_verifier/data/__init__.py",
   "src/interop_verifier/data/interop-verifier-incept-no-wits.json",
 ] as const;
+
+/** Pinned Python did-webs-resolver checkout used by DID interop tests. */
+export const DID_WEBS_RESOLVER_INTEROP_REPO = "https://github.com/kentbull/did-webs-resolver.git";
+export const DID_WEBS_RESOLVER_INTEROP_REF = "refs/heads/clean-up-deps";
+export const DID_WEBS_RESOLVER_INTEROP_COMMIT = "8395277f32b37129fa6ef734c9f3902bb6cbbcbc";
+export const DID_WEBS_RESOLVER_HIO_PIN = "hio==0.6.14";
+
+export interface DidWebsResolverTooling {
+  readonly root: string;
+  readonly dwsCommand: string;
+  readonly pythonCommand: string;
+}
 
 /**
  * Runs one command and returns decoded stdout/stderr.
@@ -426,6 +488,22 @@ function interopVerifierCacheRoot(): string {
   return `${cacheHome()}/tufa-interop/interop-verifier/${INTEROP_VERIFIER_COMMIT}`;
 }
 
+function didWebsResolverCacheRoot(): string {
+  return `${cacheHome()}/tufa-interop/did-webs-resolver/${DID_WEBS_RESOLVER_INTEROP_COMMIT}`;
+}
+
+function didWebsResolverCheckoutRoot(): string {
+  return `${didWebsResolverCacheRoot()}/checkout`;
+}
+
+function didWebsResolverVenvRoot(): string {
+  return `${didWebsResolverCacheRoot()}/venv`;
+}
+
+function didWebsResolverVenvBin(name: string): string {
+  return `${didWebsResolverVenvRoot()}/bin/${name}`;
+}
+
 async function pathExists(path: string): Promise<boolean> {
   try {
     await Deno.stat(path);
@@ -433,6 +511,189 @@ async function pathExists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function gitHead(path: string): Promise<string | null> {
+  if (!(await pathExists(`${path}/.git`))) {
+    return null;
+  }
+  const result = await runCmd("git", ["rev-parse", "HEAD"], Deno.env.toObject(), path);
+  return result.code === 0 ? result.stdout.trim() : null;
+}
+
+async function ensurePinnedDidWebsResolverCheckout(
+  env: Record<string, string>,
+): Promise<string> {
+  const checkout = didWebsResolverCheckoutRoot();
+  if (await gitHead(checkout) === DID_WEBS_RESOLVER_INTEROP_COMMIT) {
+    return checkout;
+  }
+
+  if (await pathExists(checkout)) {
+    await Deno.remove(checkout, { recursive: true });
+  }
+  await Deno.mkdir(checkout, { recursive: true });
+  await requireSuccess(
+    "initialize did-webs-resolver checkout",
+    runCmdWithTimeout("git", ["init"], env, 30_000, checkout),
+  );
+  await requireSuccess(
+    "fetch pinned did-webs-resolver ref",
+    runCmdWithTimeout(
+      "git",
+      [
+        "fetch",
+        "--depth",
+        "1",
+        DID_WEBS_RESOLVER_INTEROP_REPO,
+        DID_WEBS_RESOLVER_INTEROP_REF,
+      ],
+      env,
+      120_000,
+      checkout,
+    ),
+  );
+  await requireSuccess(
+    "checkout pinned did-webs-resolver commit",
+    runCmdWithTimeout(
+      "git",
+      ["checkout", "--detach", DID_WEBS_RESOLVER_INTEROP_COMMIT],
+      env,
+      30_000,
+      checkout,
+    ),
+  );
+  const head = await gitHead(checkout);
+  if (head !== DID_WEBS_RESOLVER_INTEROP_COMMIT) {
+    throw new Error(
+      `Expected did-webs-resolver ${DID_WEBS_RESOLVER_INTEROP_COMMIT}, got ${head ?? "<unknown>"}.`,
+    );
+  }
+  return checkout;
+}
+
+async function canUseDws(
+  command: string,
+  env: Record<string, string>,
+): Promise<boolean> {
+  try {
+    const result = await runCmd(command, ["--help"], env);
+    return result.code === 0 && `${result.stdout}\n${result.stderr}`.includes("dws");
+  } catch {
+    return false;
+  }
+}
+
+async function installDidWebsResolverIntoVenv(
+  python: string,
+  checkout: string,
+  env: Record<string, string>,
+): Promise<void> {
+  const venv = didWebsResolverVenvRoot();
+  if (await pathExists(venv)) {
+    await Deno.remove(venv, { recursive: true });
+  }
+  await requireSuccess(
+    "create did-webs-resolver venv",
+    runCmdWithTimeout(python, ["-m", "venv", venv], env, 120_000),
+  );
+  const venvPython = didWebsResolverVenvBin("python");
+  if (await canRunCommand("uv", ["--version"], env)) {
+    await requireSuccess(
+      "install pinned did-webs-resolver with uv",
+      runCmdWithTimeout(
+        "uv",
+        [
+          "pip",
+          "install",
+          "--python",
+          venvPython,
+          "-e",
+          checkout,
+        ],
+        env,
+        600_000,
+      ),
+    );
+    await requireSuccess(
+      "pin did-webs-resolver hio dependency with uv",
+      runCmdWithTimeout(
+        "uv",
+        [
+          "pip",
+          "install",
+          "--python",
+          venvPython,
+          DID_WEBS_RESOLVER_HIO_PIN,
+        ],
+        env,
+        240_000,
+      ),
+    );
+  } else {
+    await requireSuccess(
+      "upgrade did-webs-resolver venv packaging tools",
+      runCmdWithTimeout(
+        venvPython,
+        ["-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel"],
+        env,
+        240_000,
+      ),
+    );
+    await requireSuccess(
+      "install pinned did-webs-resolver with pip",
+      runCmdWithTimeout(
+        venvPython,
+        ["-m", "pip", "install", "-e", checkout],
+        env,
+        600_000,
+      ),
+    );
+    await requireSuccess(
+      "pin did-webs-resolver hio dependency with pip",
+      runCmdWithTimeout(
+        venvPython,
+        ["-m", "pip", "install", DID_WEBS_RESOLVER_HIO_PIN],
+        env,
+        240_000,
+      ),
+    );
+  }
+}
+
+/** Resolve a pinned Python `dws` executable for did:webs interop. */
+export async function ensurePinnedDidWebsResolver(
+  env: Record<string, string>,
+): Promise<DidWebsResolverTooling> {
+  const checkout = await ensurePinnedDidWebsResolverCheckout(env);
+  const marker = `${didWebsResolverCacheRoot()}/PIN`;
+  const markerValue = `${DID_WEBS_RESOLVER_INTEROP_COMMIT}\n${DID_WEBS_RESOLVER_HIO_PIN}`;
+  const dws = didWebsResolverVenvBin("dws");
+  const markerMatches = await pathExists(marker) ? (await Deno.readTextFile(marker)).trim() === markerValue : false;
+  if (markerMatches && await canUseDws(dws, env)) {
+    return {
+      root: checkout,
+      dwsCommand: dws,
+      pythonCommand: didWebsResolverVenvBin("python"),
+    };
+  }
+
+  const python = await resolveDidWebsResolverPython(env);
+  const installEnv = {
+    ...pyenvProbeEnv(env),
+    PIP_DISABLE_PIP_VERSION_CHECK: "1",
+  };
+  await installDidWebsResolverIntoVenv(python, checkout, installEnv);
+  if (!(await canUseDws(dws, env))) {
+    throw new Error(`Pinned did-webs-resolver install did not produce a runnable dws at ${dws}.`);
+  }
+  await Deno.mkdir(didWebsResolverCacheRoot(), { recursive: true });
+  await Deno.writeTextFile(marker, `${markerValue}\n`);
+  return {
+    root: checkout,
+    dwsCommand: dws,
+    pythonCommand: didWebsResolverVenvBin("python"),
+  };
 }
 
 /** Resolve the checked-in KERIpy witness config directory. */
@@ -482,7 +743,7 @@ export async function waitForHealth(port: number): Promise<void> {
 }
 
 /** Wait until one specific HTTP URL responds with any 2xx status. */
-async function waitForHttpOk(url: string): Promise<void> {
+export async function waitForHttpOk(url: string): Promise<void> {
   const deadline = Date.now() + 15_000;
   let lastError = `HTTP probe did not return 2xx for ${url}`;
   while (Date.now() < deadline) {
@@ -502,6 +763,36 @@ async function waitForHttpOk(url: string): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 200));
   }
   throw new Error(lastError);
+}
+
+async function tcpPortIsListening(port: number): Promise<boolean> {
+  try {
+    const connection = await Deno.connect({
+      hostname: "127.0.0.1",
+      port,
+    });
+    connection.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function assertTcpPortsFree(
+  ports: readonly number[],
+  label: string,
+): Promise<void> {
+  const occupied: number[] = [];
+  for (const port of ports) {
+    if (await tcpPortIsListening(port)) {
+      occupied.push(port);
+    }
+  }
+  if (occupied.length > 0) {
+    throw new Error(
+      `${label} expected free ports but these are already listening: ${occupied.join(", ")}`,
+    );
+  }
 }
 
 /** Wait until a KERIpy witness exposes either controller or witness OOBI HTTP. */
@@ -696,6 +987,54 @@ async function resolvePython314Command(
 
   throw new Error(
     `KERIpy interop requires Python >= 3.14. Tried: ${candidates.join(", ")}`,
+  );
+}
+
+async function canUsePythonForDidWebsResolver(
+  command: string,
+  env: Record<string, string>,
+): Promise<boolean> {
+  try {
+    const result = await runCmd(command, ["--version"], env);
+    const version = parsePythonVersion(`${result.stdout}\n${result.stderr}`);
+    return result.code === 0 && !!version
+      && version.major === 3
+      && version.minor >= 12
+      && version.minor < 14;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveDidWebsResolverPython(
+  env: Record<string, string>,
+): Promise<string> {
+  const probeEnv = pyenvProbeEnv(env);
+  const candidates: string[] = [];
+  const explicit = Deno.env.get("DID_WEBS_RESOLVER_PYTHON");
+  if (explicit) {
+    candidates.push(explicit);
+  }
+
+  try {
+    const pyenvWhich = await runCmd("pyenv", ["which", "python"], probeEnv);
+    const resolved = pyenvWhich.stdout.trim();
+    if (pyenvWhich.code === 0 && resolved.length > 0) {
+      candidates.push(resolved);
+    }
+  } catch {
+    // Fall through to PATH candidates.
+  }
+
+  candidates.push("python3.13", "python3.12", "python3");
+  for (const candidate of candidates) {
+    if (await canUsePythonForDidWebsResolver(candidate, probeEnv)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `did-webs-resolver requires Python >= 3.12 and < 3.14. Tried: ${candidates.join(", ")}`,
   );
 }
 
@@ -1211,6 +1550,59 @@ export async function startKeriPyWitnessHarness(
     ctx.kliCommand,
     nodes,
     children,
+  );
+}
+
+/** Start KERIpy's fixed-port demo witness topology with its built-in curls config. */
+export async function startKeriPyWitnessDemoHarness(
+  ctx: InteropContext,
+  options: KeriPyWitnessDemoHarnessOptions = {},
+): Promise<KeriPyWitnessHarness> {
+  await ensurePinnedKeripyFixtures();
+  const home = await Deno.makeTempDir({ prefix: "keripy-witness-demo-home-" });
+  const base = `interop-demo-wits-${crypto.randomUUID().slice(0, 8)}`;
+  const kliCommand = options.kliCommand ?? ctx.kliCommand;
+  const useBase = options.useBase ?? true;
+  const env = {
+    ...ctx.env,
+    HOME: home,
+  };
+  await assertTcpPortsFree(
+    KERIPY_DEMO_WITNESS_NODES.flatMap((node) => [node.httpPort, node.tcpPort]),
+    "KERIpy witness demo",
+  );
+  const args = ["witness", "demo"];
+  if (useBase) {
+    args.push("--base", base);
+  }
+  const child = spawnChild(
+    kliCommand,
+    args,
+    env,
+    keripyInteropFixtureRoot(),
+  );
+
+  try {
+    for (const node of KERIPY_DEMO_WITNESS_NODES) {
+      await waitForHttpOk(`${node.httpOrigin}/oobi/${node.pre}`);
+      await waitForHttpOk(node.controllerOobi);
+      await waitForHttpOk(node.witnessOobi);
+    }
+  } catch (error) {
+    const details = await stopChild(child);
+    throw new Error(
+      `KERIpy witness demo did not become ready: ${error instanceof Error ? error.message : String(error)}\n${details}`,
+    );
+  }
+
+  return new KeriPyWitnessHarness(
+    home,
+    useBase ? base : "",
+    "",
+    env,
+    kliCommand,
+    KERIPY_DEMO_WITNESS_NODES,
+    [child],
   );
 }
 

--- a/packages/keri/test/unit/did/webs.test.ts
+++ b/packages/keri/test/unit/did/webs.test.ts
@@ -1,0 +1,198 @@
+// @file-test-lane app-fast-parallel
+
+import { run } from "effection";
+import { assertEquals, assertThrows } from "jsr:@std/assert";
+import { createAgentRuntime } from "../../../src/app/agent-runtime.ts";
+import { dwsGenerateCommand } from "../../../src/app/cli/did.ts";
+import { createHabery } from "../../../src/app/habbing.ts";
+import {
+  bindDesignatedAliases,
+  DEFAULT_DESIGNATED_ALIASES_REGISTRY_NAME,
+  DESIGNATED_ALIASES_SCHEMA_SAID,
+  didWebsArtifactUrls,
+  listActiveDesignatedAliasCredentials,
+  parseDid,
+  pinDesignatedAliasesSchema,
+} from "../../../src/did/index.ts";
+
+Deno.test("did/webs - parses DID Webs host, path, AID, and artifact URLs", () => {
+  const parsed = parseDid("did:webs:127.0.0.1%3A7678:dws:EAid?meta=true");
+  assertEquals(parsed.kind, "webs");
+  assertEquals(parsed.aid, "EAid");
+  if (parsed.kind !== "webs") {
+    throw new Error("Expected did:webs parse result.");
+  }
+  assertEquals(parsed.host, "127.0.0.1:7678");
+  assertEquals(parsed.path, ["dws"]);
+  assertEquals(didWebsArtifactUrls("did:webs:127.0.0.1%3A7678:dws:EAid?meta=true", { scheme: "http" }), {
+    didJson: "http://127.0.0.1:7678/dws/EAid/did.json?meta=true",
+    keriCesr: "http://127.0.0.1:7678/dws/EAid/keri.cesr",
+  });
+});
+
+Deno.test("did/webs - rejects raw port separators", () => {
+  assertThrows(
+    () => parseDid("did:webs:127.0.0.1:7678:dws:EAid"),
+    Error,
+    "must encode host ports",
+  );
+});
+
+Deno.test("did/webs - pins DA schema from JSON resource and rebinds active aliases", async () => {
+  await run(function*() {
+    const hby = yield* createHabery({
+      name: `did-webs-${crypto.randomUUID()}`,
+      temp: true,
+    });
+    const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+    try {
+      const hab = hby.makeHab("issuer", undefined, {
+        transferable: true,
+        icount: 1,
+        isith: "1",
+        ncount: 1,
+        nsith: "1",
+        toad: 0,
+      });
+      const schema = pinDesignatedAliasesSchema(runtime);
+      assertEquals(schema.said, DESIGNATED_ALIASES_SCHEMA_SAID);
+
+      const first = bindDesignatedAliases(runtime, {
+        alias: "issuer",
+        dids: [
+          `did:webs:127.0.0.1%3A7678:dws:${hab.pre}`,
+          `did:keri:${hab.pre}`,
+        ],
+      });
+      assertEquals(first.revoked, []);
+
+      const second = bindDesignatedAliases(runtime, {
+        alias: "issuer",
+        dids: [`did:webs:example.com:dws:${hab.pre}`],
+      });
+      assertEquals(second.revoked, [first.issued]);
+
+      const active = listActiveDesignatedAliasCredentials(runtime, hab.pre);
+      assertEquals(active.map((item) => item.creder.said), [second.issued]);
+      assertEquals(active.flatMap((item) => item.aliases), [
+        `did:webs:example.com:dws:${hab.pre}`,
+      ]);
+    } finally {
+      yield* runtime.close();
+      yield* hby.close(true);
+    }
+  });
+});
+
+Deno.test("did/webs - bind reuses existing DA registry across runtime reopen", async () => {
+  const headDirPath = await Deno.makeTempDir({ prefix: "dws-bind-registry-" });
+  const name = `did-webs-bind-${crypto.randomUUID()}`;
+  const alias = "issuer";
+  try {
+    let aid = "";
+    let firstRegistry = "";
+    let firstIssued = "";
+
+    await run(function*() {
+      const hby = yield* createHabery({
+        name,
+        headDirPath,
+        skipConfig: true,
+      });
+      const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+      try {
+        const hab = hby.makeHab(alias, undefined, {
+          transferable: true,
+          icount: 1,
+          isith: "1",
+          ncount: 1,
+          nsith: "1",
+          toad: 0,
+        });
+        aid = hab.pre;
+        const first = bindDesignatedAliases(runtime, {
+          alias,
+          dids: [`did:webs:example.com:dws:${aid}`],
+        });
+        firstRegistry = first.registry;
+        firstIssued = first.issued;
+      } finally {
+        yield* runtime.close();
+        yield* hby.close();
+      }
+    });
+
+    await run(function*() {
+      const hby = yield* createHabery({
+        name,
+        headDirPath,
+        skipConfig: true,
+      });
+      const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+      try {
+        const second = bindDesignatedAliases(runtime, {
+          alias,
+          dids: [`did:webs:example.org:dws:${aid}`],
+        });
+        assertEquals(second.registryName, DEFAULT_DESIGNATED_ALIASES_REGISTRY_NAME);
+        assertEquals(second.registry, firstRegistry);
+        assertEquals(second.revoked, [firstIssued]);
+      } finally {
+        yield* runtime.close();
+        yield* hby.close();
+      }
+    });
+  } finally {
+    await Deno.remove(headDirPath, { recursive: true }).catch(() => undefined);
+  }
+});
+
+Deno.test("did/webs - CLI generate writes artifacts under the DID path", async () => {
+  const headDirPath = await Deno.makeTempDir({ prefix: "dws-generate-" });
+  try {
+    await run(function*() {
+      const name = `did-webs-cli-${crypto.randomUUID()}`;
+      const hby = yield* createHabery({
+        name,
+        headDirPath,
+        skipConfig: true,
+      });
+      const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+      let did = "";
+      try {
+        const hab = hby.makeHab("issuer", undefined, {
+          transferable: true,
+          icount: 1,
+          isith: "1",
+          ncount: 1,
+          nsith: "1",
+          toad: 0,
+        });
+        did = `did:webs:example.com:dws:${hab.pre}`;
+        bindDesignatedAliases(runtime, {
+          alias: "issuer",
+          dids: [did],
+        });
+      } finally {
+        yield* runtime.close();
+        yield* hby.close();
+      }
+
+      const outputDir = `${headDirPath}/web-root`;
+      yield* dwsGenerateCommand({
+        name,
+        headDirPath,
+        alias: "issuer",
+        did,
+        outputDir,
+      });
+
+      const aid = did.split(":").at(-1);
+      const artifactDir = `${outputDir}/dws/${aid}`;
+      assertEquals(Deno.statSync(`${artifactDir}/did.json`).isFile, true);
+      assertEquals(Deno.statSync(`${artifactDir}/keri.cesr`).isFile, true);
+    });
+  } finally {
+    await Deno.remove(headDirPath, { recursive: true }).catch(() => undefined);
+  }
+});

--- a/packages/tufa/src/cli/command-definitions.ts
+++ b/packages/tufa/src/cli/command-definitions.ts
@@ -9,6 +9,7 @@
 import { Command } from "npm:commander@^10.0.1";
 import { registerChallengeCmds } from "./command-definitions/challenge.ts";
 import { registerCredentialCmds } from "./command-definitions/credentials.ts";
+import { registerDidCmds } from "./command-definitions/did.ts";
 import { registerEndpointCmds } from "./command-definitions/endpoints.ts";
 import { registerIdentityCmds } from "./command-definitions/identity.ts";
 import { registerLifecycleCmds } from "./command-definitions/lifecycle.ts";
@@ -28,6 +29,7 @@ export function registerCmds(
   registerIdentityCmds(program, dispatch);
   registerChallengeCmds(program, dispatch);
   registerCredentialCmds(program, dispatch);
+  registerDidCmds(program, dispatch);
   registerMessagingCmds(program, dispatch);
   registerEndpointCmds(program, dispatch);
   registerNotificationCmds(program, dispatch);

--- a/packages/tufa/src/cli/command-definitions/did.ts
+++ b/packages/tufa/src/cli/command-definitions/did.ts
@@ -1,0 +1,129 @@
+/** Commander registrations for DID Webs and DID KERI operations. */
+import { Command } from "npm:commander@^10.0.1";
+import type { CommandDispatch } from "../command-types.ts";
+
+export function registerDidCmds(
+  program: Command,
+  dispatch: CommandDispatch,
+): void {
+  registerDwsCmds(program, dispatch);
+  registerDkrCmds(program, dispatch);
+}
+
+function addStoreOptions(cmd: Command): Command {
+  return cmd
+    .requiredOption("-n, --name <name>", "Keystore name")
+    .option("-b, --base <base>", "Optional base path prefix")
+    .option("--compat", "Use KERIpy compatibility-mode path layout")
+    .option(
+      "--head-dir <dir>",
+      "Directory override for database and keystore root",
+    )
+    .option("-p, --passcode <passcode>", "Encryption passcode for keystore");
+}
+
+function addDidOption(cmd: Command): Command {
+  return cmd.requiredOption("--did <did>", "DID to use");
+}
+
+function dispatchArgs(options: Record<string, unknown>): Record<string, unknown> {
+  const { headDir, ...rest } = options;
+  return {
+    ...rest,
+    headDirPath: headDir,
+  };
+}
+
+function registerDwsCmds(program: Command, dispatch: CommandDispatch): void {
+  const dws = program.command("dws").description("DID Webs operations");
+
+  addStoreOptions(
+    dws.command("bind")
+      .description("Bind a local AID to replacement designated-alias ACDC")
+      .requiredOption("-a, --alias <alias>", "Local identifier alias")
+      .requiredOption(
+        "--did <did>",
+        "Designated alias DID; may be repeated",
+        (value: string, prev: string[] = []) => {
+          prev.push(value);
+          return prev;
+        },
+        [],
+      )
+      .option("--registry-name <name>", "Designated-alias registry name")
+      .option("--no-create-registry", "Require the registry to already exist")
+      .option(
+        "--allow-external-did",
+        "Allow opaque non-KERI DID aliases as self-attested DA values",
+      ),
+  ).action((options: Record<string, unknown>) => {
+    dispatch({ name: "dws.bind", args: dispatchArgs(options) });
+  });
+
+  addDidOption(
+    addStoreOptions(
+      dws.command("generate")
+        .description("Generate static did:webs artifacts")
+        .requiredOption("-a, --alias <alias>", "Local identifier alias")
+        .requiredOption("--output-dir <dir>", "Directory for generated artifacts")
+        .option("--meta", "Write DID Resolution Result envelope to did.json"),
+    ),
+  ).action((options: Record<string, unknown>) => {
+    dispatch({ name: "dws.generate", args: dispatchArgs(options) });
+  });
+
+  addDidOption(
+    addStoreOptions(
+      dws.command("resolve")
+        .description("Resolve and verify a did:webs identifier")
+        .option("--meta", "Emit DID Resolution Result")
+        .option("--insecure-http", "Use http:// artifact URLs for localhost/dev workflows"),
+    ),
+  ).action((options: Record<string, unknown>) => {
+    dispatch({ name: "dws.resolve", args: dispatchArgs(options) });
+  });
+
+  addStoreOptions(
+    dws.command("resolver")
+      .description("Run Universal Resolver compatible DID service")
+      .option("--port <port>", "HTTP port", (value: string) => Number(value), 7723)
+      .option("--listen-host <host>", "Listen host", "127.0.0.1")
+      .option("--static-files-dir <dir>", "Static artifact root directory")
+      .option("--did-path <path>", "DID artifact path prefix")
+      .option("--dynamic", "Serve dynamic did.json and keri.cesr for hosted AIDs")
+      .option(
+        "--hosted-prefix <aid>",
+        "Hosted AID prefix; may be repeated",
+        (value: string, prev: string[] = []) => {
+          prev.push(value);
+          return prev;
+        },
+        [],
+      )
+      .option("--insecure-http", "Use http:// when this resolver fetches did:webs artifacts"),
+  ).action((options: Record<string, unknown>) => {
+    dispatch({ name: "dws.resolver", args: dispatchArgs(options) });
+  });
+}
+
+function registerDkrCmds(program: Command, dispatch: CommandDispatch): void {
+  const dkr = program.command("dkr").description("DID KERI operations");
+  addDidOption(
+    addStoreOptions(
+      dkr.command("resolve")
+        .description("Resolve a did:keri identifier")
+        .option(
+          "--oobi <url>",
+          "OOBI URL; may be repeated",
+          (value: string, prev: string[] = []) => {
+            prev.push(value);
+            return prev;
+          },
+          [],
+        )
+        .option("--meta", "Emit DID Resolution Result"),
+    ),
+  ).action((options: Record<string, unknown>) => {
+    dispatch({ name: "dkr.resolve", args: dispatchArgs(options) });
+  });
+}

--- a/packages/tufa/src/cli/dws.ts
+++ b/packages/tufa/src/cli/dws.ts
@@ -1,0 +1,94 @@
+/** Long-lived `tufa dws resolver` service command. */
+import type { Operation } from "effection";
+import {
+  type CesrBodyMode,
+  consoleLogger,
+  createAgentRuntime,
+  normalizeCesrBodyMode,
+  ValidationError,
+} from "keri-ts/runtime";
+import { startServer } from "../host/http-server.ts";
+import { setupHby } from "./support/existing.ts";
+
+interface DwsResolverArgs {
+  port?: number;
+  listenHost?: string;
+  name?: string;
+  base?: string;
+  headDirPath?: string;
+  passcode?: string;
+  compat?: boolean;
+  cesrBodyMode?: CesrBodyMode;
+  staticFilesDir?: string;
+  didPath?: string;
+  dynamic?: boolean;
+  hostedPrefixes: string[];
+  insecureHttp?: boolean;
+}
+
+/** Run the DID Webs Universal Resolver and optional artifact host. */
+export function* dwsResolverCommand(args: Record<string, unknown>): Operation<void> {
+  const commandArgs: DwsResolverArgs = {
+    port: args.port ? Number(args.port) : 7723,
+    listenHost: args.listenHost as string | undefined,
+    name: args.name as string | undefined,
+    base: args.base as string | undefined,
+    headDirPath: args.headDirPath as string | undefined,
+    passcode: args.passcode as string | undefined,
+    compat: args.compat as boolean | undefined,
+    cesrBodyMode: normalizeCesrBodyMode(args.cesrBodyMode as string | undefined),
+    staticFilesDir: args.staticFilesDir as string | undefined,
+    didPath: args.didPath as string | undefined,
+    dynamic: args.dynamic as boolean | undefined,
+    hostedPrefixes: asStringList(args.hostedPrefix),
+    insecureHttp: args.insecureHttp as boolean | undefined,
+  };
+  const port = commandArgs.port ?? 7723;
+  if (!Number.isFinite(port) || port < 1 || port > 65535) {
+    throw new ValidationError(`Invalid port number: ${port}.`);
+  }
+  if (!commandArgs.name) {
+    throw new ValidationError("Name is required.");
+  }
+  if ((commandArgs.dynamic ?? false) && commandArgs.hostedPrefixes.length === 0) {
+    throw new ValidationError("Dynamic DID Webs hosting requires at least one --hosted-prefix.");
+  }
+  const hby = yield* setupHby(
+    commandArgs.name,
+    commandArgs.base ?? "",
+    commandArgs.passcode,
+    false,
+    commandArgs.headDirPath,
+    {
+      compat: commandArgs.compat ?? false,
+      readonly: false,
+      skipConfig: true,
+      skipSignator: false,
+      cesrBodyMode: commandArgs.cesrBodyMode,
+    },
+  );
+  const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+  try {
+    yield* startServer(port, consoleLogger, runtime, {
+      hostname: commandArgs.listenHost ?? "127.0.0.1",
+      hostedPrefixes: commandArgs.hostedPrefixes,
+      dwsStaticFilesDir: commandArgs.staticFilesDir,
+      dwsDidPath: commandArgs.didPath,
+      dwsDynamic: commandArgs.dynamic ?? false,
+      dwsInsecureHttp: commandArgs.insecureHttp ?? false,
+      onListen: ({ hostname, port }) => {
+        console.log(`DID resolver listening on http://${hostname}:${port}`);
+      },
+    });
+  } finally {
+    yield* runtime.close();
+    yield* hby.close();
+  }
+}
+
+function asStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string");
+  }
+  return typeof value === "string" ? [value] : [];
+}

--- a/packages/tufa/src/cli/handlers.ts
+++ b/packages/tufa/src/cli/handlers.ts
@@ -178,6 +178,11 @@ export function createCmdHandlers(): Map<string, CommandHandler> {
       lazyCommand(() => import("keri-ts/cli"), "multisigRotateCommand"),
     ],
     ["verifier.run", lazyCommand(() => import("keri-ts/cli"), "verifierRunCommand")],
+    ["dws.bind", lazyCommand(() => import("keri-ts/cli"), "dwsBindCommand")],
+    ["dws.generate", lazyCommand(() => import("keri-ts/cli"), "dwsGenerateCommand")],
+    ["dws.resolve", lazyCommand(() => import("keri-ts/cli"), "dwsResolveCommand")],
+    ["dws.resolver", lazyCommand(() => import("./dws.ts"), "dwsResolverCommand")],
+    ["dkr.resolve", lazyCommand(() => import("keri-ts/cli"), "dkrResolveCommand")],
     ["hook.demo", lazyCommand(() => import("./hook.ts"), "hookDemoCommand")],
     ["agent", lazyCommand(() => import("./agent.ts"), "agentCommand")],
     [

--- a/packages/tufa/src/http/protocol-handler.ts
+++ b/packages/tufa/src/http/protocol-handler.ts
@@ -8,6 +8,8 @@
  */
 import type { AgentRuntime, ProtocolHostPolicy } from "keri-ts/runtime";
 import { buildProtocolRequestContext } from "./protocol/context.ts";
+import { classifyDidResolutionRoute, handleDidResolutionRoute } from "./protocol/endpoints/did-resolution.ts";
+import { classifyDwsArtifactRoute, handleDwsArtifactRoute } from "./protocol/endpoints/dws-artifacts.ts";
 import {
   classifyCesrIngressRoute,
   classifyGenericCesrIngressRoute,
@@ -52,6 +54,8 @@ export function classifyProtocolRoute(
   context: ProtocolRequestContext,
 ): ProtocolRoute {
   return classifyHealthRoute(context)
+    ?? classifyDidResolutionRoute(context)
+    ?? classifyDwsArtifactRoute(context)
     ?? classifyMailboxAdminRoute(context)
     ?? classifyWitnessHttpRoute(context)
     ?? classifyOobiRoute(context)
@@ -67,6 +71,10 @@ async function dispatchProtocolRoute(
   switch (route.kind) {
     case "health":
       return handleHealthRoute();
+    case "didResolution":
+      return await handleDidResolutionRoute(context, route.did);
+    case "dwsArtifact":
+      return await handleDwsArtifactRoute(context, route);
     case "ambiguousHostedPath":
       return new Response(route.message, {
         status: 409,

--- a/packages/tufa/src/http/protocol/endpoints/did-resolution.ts
+++ b/packages/tufa/src/http/protocol/endpoints/did-resolution.ts
@@ -1,0 +1,107 @@
+/** Universal Resolver compatible DID route. */
+import { run } from "effection";
+import {
+  didResolutionError,
+  resolveDidKeri,
+  resolveDidWebs,
+} from "keri-ts/runtime";
+import type { ProtocolRequestContext, ProtocolRoute } from "../types.ts";
+
+const IDENTIFIERS_PREFIX = "/1.0/identifiers/";
+
+/** Classify `/1.0/identifiers/{did}` requests. */
+export function classifyDidResolutionRoute(
+  context: ProtocolRequestContext,
+): ProtocolRoute | null {
+  if (context.method !== "GET" || !context.pathname.startsWith(IDENTIFIERS_PREFIX)) {
+    return null;
+  }
+  const encoded = context.pathname.slice(IDENTIFIERS_PREFIX.length);
+  if (encoded.length === 0) {
+    return null;
+  }
+  return { kind: "didResolution", did: decodeDidIdentifierPath(encoded) };
+}
+
+/** Handle one Universal Resolver request. */
+export async function handleDidResolutionRoute(
+  context: ProtocolRequestContext,
+  did: string,
+): Promise<Response> {
+  const meta = wantsResolutionResult(context.req, context.url);
+  if (!context.runtime) {
+    return jsonResponse(
+      didResolutionError("internalError", "DID resolver runtime is not available."),
+      500,
+    );
+  }
+  try {
+    const oobis = context.url.searchParams.getAll("oobi");
+    const result = did.startsWith("did:webs:") || did.startsWith("did:web:")
+      ? await run(() =>
+        resolveDidWebs(context.runtime!, {
+          did,
+          metadata: meta,
+          insecureHttp: context.policy.dwsInsecureHttp ?? false,
+        })
+      )
+      : did.startsWith("did:keri:")
+      ? await run(() =>
+        resolveDidKeri(context.runtime!, {
+          did,
+          oobis,
+          metadata: meta,
+        })
+      )
+      : null;
+    if (!result) {
+      return jsonResponse(
+        didResolutionError("methodNotSupported", `Unsupported DID method for ${did}.`),
+        meta ? 200 : 400,
+      );
+    }
+    return jsonResponse(
+      meta ? result.resolution : result.document,
+      200,
+      meta ? "application/did-resolution+json" : "application/did+json",
+    );
+  } catch (error) {
+    return jsonResponse(
+      didResolutionError(
+        "notFound",
+        error instanceof Error ? error.message : String(error),
+      ),
+      meta ? 200 : 404,
+    );
+  }
+}
+
+function wantsResolutionResult(req: Request, url: URL): boolean {
+  if (url.searchParams.get("meta") === "true") {
+    return true;
+  }
+  return (req.headers.get("accept") ?? "").toLowerCase().includes("application/did-resolution");
+}
+
+function decodeDidIdentifierPath(encoded: string): string {
+  if (encoded.startsWith("did:")) {
+    return encoded;
+  }
+  try {
+    const decoded = decodeURIComponent(encoded);
+    return decoded.startsWith("did:") ? decoded : encoded;
+  } catch {
+    return encoded;
+  }
+}
+
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  contentType = "application/did+json",
+): Response {
+  return new Response(`${JSON.stringify(body, null, 2)}\n`, {
+    status,
+    headers: { "Content-Type": contentType },
+  });
+}

--- a/packages/tufa/src/http/protocol/endpoints/dws-artifacts.ts
+++ b/packages/tufa/src/http/protocol/endpoints/dws-artifacts.ts
@@ -1,0 +1,145 @@
+/** Static and dynamic `did:webs` artifact routes. */
+import {
+  didWebsFromArtifactRequest,
+  generateDidWebsArtifacts,
+  ValidationError,
+} from "keri-ts/runtime";
+import type { ProtocolRequestContext, ProtocolRoute } from "../types.ts";
+
+/** Classify configured `did.json` and `keri.cesr` artifact routes. */
+export function classifyDwsArtifactRoute(
+  context: ProtocolRequestContext,
+): ProtocolRoute | null {
+  if (context.method !== "GET") {
+    return null;
+  }
+  if (!context.policy.dwsDynamic && !context.policy.dwsStaticFilesDir) {
+    return null;
+  }
+  const segments = context.pathname.split("/").filter((part) => part.length > 0);
+  const configuredPath = didPathSegments(context.policy.dwsDidPath);
+  if (!pathPrefixMatches(segments, configuredPath)) {
+    return null;
+  }
+  const remaining = segments.slice(configuredPath.length);
+  if (remaining.length !== 2) {
+    return null;
+  }
+  const [aid, artifact] = remaining;
+  if (artifact !== "did.json" && artifact !== "keri.cesr") {
+    return null;
+  }
+  return { kind: "dwsArtifact", aid, artifact };
+}
+
+/** Serve one configured artifact route from dynamic state or static files. */
+export async function handleDwsArtifactRoute(
+  context: ProtocolRequestContext,
+  route: Extract<ProtocolRoute, { kind: "dwsArtifact" }>,
+): Promise<Response> {
+  if (context.policy.dwsDynamic && context.runtime && dynamicAidAllowed(context, route.aid)) {
+    return dynamicArtifactResponse(context, route);
+  }
+  if (context.policy.dwsStaticFilesDir) {
+    return await staticArtifactResponse(context, route);
+  }
+  return new Response("Not Found", {
+    status: 404,
+    headers: { "Content-Type": "text/plain" },
+  });
+}
+
+function dynamicArtifactResponse(
+  context: ProtocolRequestContext,
+  route: Extract<ProtocolRoute, { kind: "dwsArtifact" }>,
+): Response {
+  try {
+    const did = didWebsFromArtifactRequest({
+      host: context.req.headers.get("host") ?? context.url.host,
+      didPath: didPathSegments(context.policy.dwsDidPath),
+      aid: route.aid,
+    });
+    const artifacts = generateDidWebsArtifacts(context.runtime!, { did });
+    const bytes = route.artifact === "did.json" ? artifacts.didJson : artifacts.keriCesr;
+    return new Response(bodyBuffer(bytes), {
+      headers: {
+        "Content-Type": route.artifact === "did.json" ? "application/did+json" : "application/cesr",
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(message, {
+      status: error instanceof ValidationError ? 400 : 500,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+}
+
+async function staticArtifactResponse(
+  context: ProtocolRequestContext,
+  route: Extract<ProtocolRoute, { kind: "dwsArtifact" }>,
+): Promise<Response> {
+  const root = context.policy.dwsStaticFilesDir!;
+  try {
+    const path = staticArtifactPath(root, context.policy.dwsDidPath, route.aid, route.artifact);
+    const bytes = await Deno.readFile(path);
+    return new Response(bodyBuffer(bytes), {
+      headers: {
+        "Content-Type": route.artifact === "did.json" ? "application/did+json" : "application/cesr",
+      },
+    });
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return new Response(error.message, {
+        status: 400,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+    return new Response("Not Found", {
+      status: 404,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+}
+
+function bodyBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function dynamicAidAllowed(context: ProtocolRequestContext, aid: string): boolean {
+  const hosted = context.policy.hostedPrefixes ?? [];
+  return hosted.includes(aid);
+}
+
+function staticArtifactPath(
+  root: string,
+  didPath: string | undefined,
+  aid: string,
+  artifact: "did.json" | "keri.cesr",
+): string {
+  const normalizedRoot = root.replace(/\/+$/u, "");
+  const prefix = didPathSegments(didPath).map(safeSegment).join("/");
+  const parts = [normalizedRoot, prefix, safeSegment(aid), artifact].filter((part) => part.length > 0);
+  return parts.join("/");
+}
+
+function didPathSegments(path: string | undefined): string[] {
+  return (path ?? "").split("/").filter((part) => part.length > 0);
+}
+
+function pathPrefixMatches(
+  segments: readonly string[],
+  prefix: readonly string[],
+): boolean {
+  if (segments.length < prefix.length) {
+    return false;
+  }
+  return prefix.every((part, index) => segments[index] === part);
+}
+
+function safeSegment(segment: string): string {
+  if (segment.includes("/") || segment === ".." || segment.includes("\0")) {
+    throw new ValidationError(`Unsafe path segment ${segment}.`);
+  }
+  return segment;
+}

--- a/packages/tufa/src/http/protocol/types.ts
+++ b/packages/tufa/src/http/protocol/types.ts
@@ -29,6 +29,8 @@ export interface ProtocolRequestContext {
 /** Path-level route decision before any request body is read. */
 export type ProtocolRoute =
   | { kind: "health" }
+  | { kind: "didResolution"; did: string }
+  | { kind: "dwsArtifact"; aid: string; artifact: "did.json" | "keri.cesr" }
   | { kind: "mailboxAdmin"; mailboxAid: string }
   | { kind: "witnessReceiptsPost"; witnessHab: Hab }
   | { kind: "witnessReceiptsGet"; witnessHab: Hab }

--- a/packages/tufa/test/cli.test.ts
+++ b/packages/tufa/test/cli.test.ts
@@ -180,6 +180,68 @@ Deno.test("tufa/cli - IPEX runtime knobs dispatch renamed args", () => {
   assertEquals(join.args.pollBudgetMs, 1500);
 });
 
+Deno.test("tufa/cli - DID Webs and DID KERI commands dispatch expected handlers", () => {
+  const bind = parseCommandSelection([
+    "dws",
+    "bind",
+    "-n",
+    "store",
+    "-a",
+    "issuer",
+    "--did",
+    "did:webs:example.com:EAid",
+    "--did",
+    "did:keri:EAid",
+  ]);
+  assertEquals(bind.name, "dws.bind");
+  assertEquals(bind.args.did, ["did:webs:example.com:EAid", "did:keri:EAid"]);
+
+  const generate = parseCommandSelection([
+    "dws",
+    "generate",
+    "-n",
+    "store",
+    "-a",
+    "issuer",
+    "--did",
+    "did:webs:example.com:dws:EAid",
+    "--output-dir",
+    "/tmp/dws",
+  ]);
+  assertEquals(generate.name, "dws.generate");
+  assertEquals(generate.args.outputDir, "/tmp/dws");
+
+  const resolver = parseCommandSelection([
+    "dws",
+    "resolver",
+    "-n",
+    "store",
+    "--port",
+    "7676",
+    "--static-files-dir",
+    "/tmp/web",
+    "--did-path",
+    "dws",
+    "--insecure-http",
+  ]);
+  assertEquals(resolver.name, "dws.resolver");
+  assertEquals(resolver.args.port, 7676);
+  assertEquals(resolver.args.insecureHttp, true);
+
+  const dkr = parseCommandSelection([
+    "dkr",
+    "resolve",
+    "-n",
+    "store",
+    "--did",
+    "did:keri:EAid",
+    "--oobi",
+    "http://127.0.0.1:5642/oobi/EAid",
+  ]);
+  assertEquals(dkr.name, "dkr.resolve");
+  assertEquals(dkr.args.oobi, ["http://127.0.0.1:5642/oobi/EAid"]);
+});
+
 Deno.test("tufa/cli - multisig runtime knobs dispatch renamed args", () => {
   const incept = parseCommandSelection([
     "multisig",

--- a/packages/tufa/test/integration/did-webs.test.ts
+++ b/packages/tufa/test/integration/did-webs.test.ts
@@ -1,0 +1,117 @@
+import { action, type Operation, run, spawn } from "effection";
+import { assertEquals } from "jsr:@std/assert";
+import {
+  bindDesignatedAliases,
+  createAgentRuntime,
+  createHabery,
+  generateDidWebsArtifacts,
+  resolveDidWebs,
+} from "keri-ts/runtime";
+import { startServer } from "../../src/host/http-server.ts";
+import { reserveTcpPort, waitForServer, waitForTaskHalt } from "../test-helpers.ts";
+
+Deno.test("tufa/dws - static artifacts resolve through the Tufa HTTP artifact route", async () => {
+  await run(function*(): Operation<void> {
+    const port = reserveTcpPort();
+    const webRoot = yield* tempDirOp();
+    const issuerHby = yield* createHabery({
+      name: `dws-static-issuer-${crypto.randomUUID()}`,
+      temp: true,
+    });
+    const resolverHby = yield* createHabery({
+      name: `dws-static-resolver-${crypto.randomUUID()}`,
+      temp: true,
+    });
+    const issuerRuntime = yield* createAgentRuntime(issuerHby, { mode: "local" });
+    const resolverRuntime = yield* createAgentRuntime(resolverHby, { mode: "local" });
+    let serverTask;
+    try {
+      const hab = issuerHby.makeHab("issuer", undefined, {
+        transferable: true,
+        icount: 1,
+        isith: "1",
+        ncount: 1,
+        nsith: "1",
+        toad: 0,
+      });
+      const did = `did:webs:127.0.0.1%3A${port}:dws:${hab.pre}`;
+      bindDesignatedAliases(issuerRuntime, {
+        alias: "issuer",
+        dids: [did, `did:keri:${hab.pre}`],
+      });
+      const artifacts = generateDidWebsArtifacts(issuerRuntime, {
+        alias: "issuer",
+        did,
+      });
+      const artifactDir = `${webRoot}/dws/${hab.pre}`;
+      Deno.mkdirSync(artifactDir, { recursive: true });
+      Deno.writeFileSync(`${artifactDir}/did.json`, artifacts.didJson);
+      Deno.writeFileSync(`${artifactDir}/keri.cesr`, artifacts.keriCesr);
+
+      serverTask = yield* spawn(function*() {
+        yield* startServer(port, undefined, resolverRuntime, {
+          dwsStaticFilesDir: webRoot,
+          dwsDidPath: "dws",
+          dwsInsecureHttp: true,
+        });
+      });
+      yield* waitForServer(port);
+
+      const resolved = yield* resolveDidWebs(resolverRuntime, {
+        did,
+        insecureHttp: true,
+      });
+      assertEquals(resolved.document.id, did);
+      assertEquals(
+        [...(resolved.document.alsoKnownAs as string[])].sort(),
+        [did, `did:keri:${hab.pre}`].sort(),
+      );
+
+      const rawUniversalResolution = yield* fetchJson(
+        `http://127.0.0.1:${port}/1.0/identifiers/${did}?meta=true`,
+      );
+      assertEquals(
+        (rawUniversalResolution as { didDocument: { id: string } }).didDocument.id,
+        did,
+      );
+
+      const encodedUniversalResolution = yield* fetchJson(
+        `http://127.0.0.1:${port}/1.0/identifiers/${encodeURIComponent(did)}?meta=true`,
+      );
+      assertEquals(
+        (encodedUniversalResolution as { didDocument: { id: string } }).didDocument.id,
+        did,
+      );
+    } finally {
+      if (serverTask) {
+        yield* waitForTaskHalt(serverTask, 100);
+      }
+      yield* issuerRuntime.close();
+      yield* resolverRuntime.close();
+      yield* issuerHby.close(true);
+      yield* resolverHby.close(true);
+      yield* removeDirOp(webRoot);
+    }
+  });
+});
+
+function* tempDirOp(): Operation<string> {
+  return yield* promiseOp(Deno.makeTempDir({ prefix: "tufa-dws-" }));
+}
+
+function* removeDirOp(path: string): Operation<void> {
+  yield* promiseOp(Deno.remove(path, { recursive: true }));
+}
+
+function* promiseOp<T>(promise: Promise<T>): Operation<T> {
+  return yield* action((resolve, reject) => {
+    promise.then(resolve, reject);
+    return () => {};
+  });
+}
+
+function* fetchJson(url: string): Operation<unknown> {
+  const response = yield* promiseOp(fetch(url));
+  assertEquals(response.status, 200);
+  return yield* promiseOp(response.json());
+}

--- a/scripts/ci/run-keri-test-group.ts
+++ b/scripts/ci/run-keri-test-group.ts
@@ -140,6 +140,10 @@ const laneConfigs: Record<string, LaneConfig> = {
     description: "Witness interop and witness CLI coverage.",
     allowAll: true,
   },
+  "interop-did-webs": {
+    description: "Pinned Python did-webs-resolver interop matrix.",
+    allowAll: true,
+  },
   "interop-gates-b": {
     description: "Gate B ready scenarios.",
     allowAll: true,

--- a/scripts/docker/did-webs-ts.sh
+++ b/scripts/docker/did-webs-ts.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-build}"
+IMAGE_NAMESPACE="${DID_WEBS_TS_IMAGE_NAMESPACE:-ghcr.io/kentbull}"
+RUNTIME_IMAGE="${DID_WEBS_TS_RUNTIME_IMAGE:-${IMAGE_NAMESPACE}/did-webs-ts-tufa}"
+INTEROP_IMAGE="${DID_WEBS_TS_INTEROP_IMAGE:-${IMAGE_NAMESPACE}/did-webs-ts-interop}"
+TAG="${DID_WEBS_TS_TAG:-$(git rev-parse --short HEAD)}"
+DOCKERFILE="${DID_WEBS_TS_DOCKERFILE:-docker/did-webs-ts/Dockerfile}"
+NODE_IMAGE_TAG="${DID_WEBS_TS_NODE_IMAGE_TAG:-25.9.0-bookworm-slim}"
+
+build_image() {
+  local target="$1"
+  local image="$2"
+  docker build \
+    --file "${DOCKERFILE}" \
+    --build-arg "NODE_IMAGE_TAG=${NODE_IMAGE_TAG}" \
+    --target "${target}" \
+    --tag "${image}:${TAG}" \
+    --tag "${image}:latest" \
+    .
+}
+
+push_image() {
+  local image="$1"
+  docker push "${image}:${TAG}"
+  docker push "${image}:latest"
+}
+
+case "${ACTION}" in
+  build)
+    build_image runtime "${RUNTIME_IMAGE}"
+    build_image interop "${INTEROP_IMAGE}"
+    ;;
+  test)
+    build_image interop "${INTEROP_IMAGE}"
+    docker run --rm "${INTEROP_IMAGE}:${TAG}"
+    ;;
+  push)
+    push_image "${RUNTIME_IMAGE}"
+    push_image "${INTEROP_IMAGE}"
+    ;;
+  build-push)
+    build_image runtime "${RUNTIME_IMAGE}"
+    build_image interop "${INTEROP_IMAGE}"
+    push_image "${RUNTIME_IMAGE}"
+    push_image "${INTEROP_IMAGE}"
+    ;;
+  *)
+    echo "Usage: $0 {build|test|push|build-push}" >&2
+    exit 64
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Adds `did:webs` and `did:keri` DID document generation/resolution support in `keri-ts`, including hosted `did.json` and `keri.cesr` artifact generation.
- Adds designated-alias ACDC schema loading from JSON, DA registry reuse, DA bind/rebind flow, and active-unrevoked DA credential projection into artifacts.
- Adds Tufa `dws bind`, `dws generate`, `dws resolve`, `dws resolver`, and `dkr resolve` surfaces plus Universal Resolver `/1.0/identifiers/{did}` routing.
- Adds pinned Python `did-webs-resolver` interop tests for witnessed did:webs artifacts in both directions, with did:keri coverage included while passing.
- Adds preflight port and HTTP OOBI probes before KERIpy OOBI resolution, uses the KERIpy witness demo fixture cwd so the required `curls` config is present, and post-installs `hio==0.6.14` for the Python resolver checkout.
- Adds Docker image build/test/publish wiring for `did-webs-ts-tufa` and `did-webs-ts-interop` plus Docker-backed interop CI.

## Validation

- `deno task fmt:check`
- `deno task lint`
- `deno task check`
- `deno task quality:check`
- `deno test -A --unstable-ffi packages/keri/test/unit/did/webs.test.ts`
- `deno test -A --unstable-ffi packages/tufa/test/cli.test.ts packages/tufa/test/integration/did-webs.test.ts`
- `deno task test:quality:keri:interop-did-webs`
- `DID_WEBS_TS_NODE_IMAGE_TAG=bookworm-slim deno task docker:did-webs-ts:test`

## Notes

- The default Dockerfile remains pinned to `node:25.9.0-bookworm-slim`; local Docker Hub metadata lookup for that exact tag timed out here, so the local Docker interop verification used the cached `node:bookworm-slim` base override.
- Local GHCR image push was attempted, but the available GitHub token lacks `write:packages`; the added workflow can publish through GitHub Actions with `GITHUB_TOKEN`.
- Reference workflow hazards found during interop are tracked in #61.