### PR TITLE
Kentbull/keri ts workstreams

### DIFF
--- a/.agents/PROJECT_LEARNINGS.md
+++ b/.agents/PROJECT_LEARNINGS.md
@@ -87,9 +87,9 @@ stay short enough to reread at session start.
 16. Local location updates must arrive through signed `/loc/scheme` replies, not
     direct writes to `locs.` / `lans.`.
 17. Interop contracts are exact: keep `lmdb` pinned to `3.4.4`, preserve
-   `LMDB_DATA_V1=true` for KERIpy interop workflows, size existing LMDB mappings
-   from stored metadata with KERIpy-compatible environment overrides, and route
-   protocol/storage CBOR through the shared CESR codec.
+    `LMDB_DATA_V1=true` for KERIpy interop workflows, size existing LMDB mappings
+    from stored metadata with KERIpy-compatible environment overrides, and route
+    protocol/storage CBOR through the shared CESR codec.
 18. Test parallelization should follow real isolation boundaries, not folder
     names. Keep lane ownership explicit and keep default CI truthful.
 19. `packages/tufa` now owns the runnable host/CLI edge; `keri-ts` root,

--- a/.agents/PROJECT_LEARNINGS.md
+++ b/.agents/PROJECT_LEARNINGS.md
@@ -103,7 +103,9 @@ stay short enough to reread at session start.
 22. DID Webs resolution is not just hosted JSON lookup: resolution must ingest
     `keri.cesr`, rebuild the DID document from KERI/VDR state, and compare it
     with the hosted `did.json`; Universal Resolver path decoding must preserve
-    method-specific `%3A` host-port encodings.
+    method-specific `%3A` host-port encodings. Verification-method projection
+    preserves numeric, flat weighted, nested weighted, and multi-clause KERI
+    threshold semantics through `ConditionalProof2022` methods.
 23. The learnings layer is part of project hygiene: compact docs when they grow
     noisy instead of preserving every step as prose.
 

--- a/.agents/PROJECT_LEARNINGS.md
+++ b/.agents/PROJECT_LEARNINGS.md
@@ -87,8 +87,9 @@ stay short enough to reread at session start.
 16. Local location updates must arrive through signed `/loc/scheme` replies, not
     direct writes to `locs.` / `lans.`.
 17. Interop contracts are exact: keep `lmdb` pinned to `3.4.4`, preserve
-    `LMDB_DATA_V1=true` for KERIpy interop workflows, and route protocol/storage
-    CBOR through the shared CESR codec.
+   `LMDB_DATA_V1=true` for KERIpy interop workflows, size existing LMDB mappings
+   from stored metadata with KERIpy-compatible environment overrides, and route
+   protocol/storage CBOR through the shared CESR codec.
 18. Test parallelization should follow real isolation boundaries, not folder
     names. Keep lane ownership explicit and keep default CI truthful.
 19. `packages/tufa` now owns the runnable host/CLI edge; `keri-ts` root,

--- a/.agents/learnings/PROJECT_LEARNINGS_CESR.md
+++ b/.agents/learnings/PROJECT_LEARNINGS_CESR.md
@@ -60,7 +60,8 @@ Persistent CESR parser, primitive, and serder memory for `keri-ts`.
     JSON-number inputs the way KERIpy still does.
 19. Weighted thresholds are now semantic CESR primitives through `Tholder`,
     including weighted/nested normalization, `limen`/`sith` projection, exact
-    threshold sizing, and `satisfy(indices)` behavior.
+    threshold sizing, left-to-right signer-slot consumption across clauses, and
+    `satisfy(indices)` behavior.
 20. Fixed-field `structing.py` values belong to CESR through
     `packages/cesr/src/primitives/structing.ts`: the right TypeScript mental
     model is plain frozen records plus companion helpers/registries, not a mini

--- a/.agents/learnings/PROJECT_LEARNINGS_KELS.md
+++ b/.agents/learnings/PROJECT_LEARNINGS_KELS.md
@@ -15,8 +15,9 @@ and KERIpy interoperability.
    promotion of the highest-value `Partial` rows with real parity evidence,
    especially `fetchTsgs` and the remaining `Komer` family.
 4. Exact interop rules matter: keep `lmdb` pinned to `3.4.4`, preserve
-   `LMDB_DATA_V1=true`, and route protocol/storage CBOR through the shared CESR
-   codec.
+   `LMDB_DATA_V1=true`, size existing mappings from stored metadata after
+   applying explicit or KERIpy-compatible environment overrides, and route
+   protocol/storage CBOR through the shared CESR codec.
 5. Typed `Suber` / `Komer` wrappers are the active parity path; the forward
    ordinal-wrapper surface is the newer `getTop*` / `getAll*` family, with old
    `getOn*` names retained only as temporary compatibility aliases.

--- a/.agents/learnings/PROJECT_LEARNINGS_KELS.md
+++ b/.agents/learnings/PROJECT_LEARNINGS_KELS.md
@@ -100,9 +100,10 @@ and KERIpy interoperability.
     route breadth, the stale/timeout continuation tail, and the last high-value
     DB parity promotions.
 27. Gate F/G bridge work is already partly real: `Exchanger` owns accepted and
-    partially signed `exn` persistence, challenge flows are live, and mailbox
-    forwarding/polling now sit on explicit shared provider storage plus durable
-    `tops.` cursors.
+    partially signed `exn` persistence, escrow promotion clears partial state
+    exactly once so accepted signatures survive for lead election and IPEX
+    evidence, challenge flows are live, and mailbox forwarding/polling now sit
+    on explicit shared provider storage plus durable `tops.` cursors.
 28. The mailbox mental model must stay explicit: provider mailbox storage is
     shared runtime-composed state above `Habery`, while remote topic cursors are
     durable habery state in `tops.`.

--- a/.agents/learnings/PROJECT_LEARNINGS_KELS.md
+++ b/.agents/learnings/PROJECT_LEARNINGS_KELS.md
@@ -89,7 +89,10 @@ and KERIpy interoperability.
     instead of private `Habery.makeGroupHab(...)` shortcuts. Accepted group
     member metadata changes only after the corresponding inception or rotation
     is present in the local KEL; pending rotations retain the prior accepted
-    `smids` / `rmids` state.
+    `smids` / `rmids` state. Tufa multisig inception files preserve structured
+    `isith` / `nsith` values, and the nested weighted public-CLI gate proves that
+    a satisfying subgroup can complete inception, interaction, endpoint-role
+    reply, and DID Webs publication without an unnecessary third signature.
 25. Delegation source-seal repair has two cases. Pending delegated events in
     `pdes` / `delegables` still use explicit delegation escrow promotion, but
     already accepted local delegated events must also pin `aess` when a later

--- a/.agents/learnings/PROJECT_LEARNINGS_KELS.md
+++ b/.agents/learnings/PROJECT_LEARNINGS_KELS.md
@@ -86,7 +86,10 @@ and KERIpy interoperability.
     group->witnessed 2-of-3 group approval. Tufa now has public CLI multisig
     `incept`, `join`, `interact`, and `rotate` surfaces over the real
     grouping/multiplexing path; interop workflows should use those CLI seams
-    instead of private `Habery.makeGroupHab(...)` shortcuts.
+    instead of private `Habery.makeGroupHab(...)` shortcuts. Accepted group
+    member metadata changes only after the corresponding inception or rotation
+    is present in the local KEL; pending rotations retain the prior accepted
+    `smids` / `rmids` state.
 25. Delegation source-seal repair has two cases. Pending delegated events in
     `pdes` / `delegables` still use explicit delegation escrow promotion, but
     already accepted local delegated events must also pin `aess` when a later

--- a/.agents/learnings/PROJECT_LEARNINGS_WITNESS_WATCHER_OBSERVER_INFRA.md
+++ b/.agents/learnings/PROJECT_LEARNINGS_WITNESS_WATCHER_OBSERVER_INFRA.md
@@ -33,8 +33,9 @@ release, and interoperability operations.
 9. Runtime version generation should stay deterministic during checks; build
    metadata is opt-in for artifact/release steps.
 10. KERIpy interop depends on exact LMDB-js behavior: keep `lmdb` pinned to
-    `3.4.4`, preserve `LMDB_DATA_V1=true`, and use the correct native-addon
-    rebuild path.
+    `3.4.4`, preserve `LMDB_DATA_V1=true`, use the correct native-addon rebuild
+    path, and size existing mappings from stored metadata after explicit,
+    `KERI_LMDB_MAP_SIZE`, or `KERI_BASER_MAP_SIZE` configuration.
 11. Cache topology is part of correctness. Interop-sensitive LMDB-v1 jobs need
     their own cache boundary.
 12. CI feedback should follow true isolation boundaries: DB, core, app/server,

--- a/.changeset/keri-lmdb-map-size.md
+++ b/.changeset/keri-lmdb-map-size.md
@@ -1,0 +1,5 @@
+---
+"keri-ts": patch
+---
+
+Size LMDB mappings from explicit options, KERIpy-compatible environment variables, and existing database metadata.

--- a/.changeset/keri-nested-weighted-did-webs.md
+++ b/.changeset/keri-nested-weighted-did-webs.md
@@ -1,0 +1,5 @@
+---
+"keri-ts": patch
+---
+
+Project weighted DID Webs thresholds as recursive `ConditionalProof2022` verification methods.

--- a/.changeset/tufa-db-dump-map-size.md
+++ b/.changeset/tufa-db-dump-map-size.md
@@ -1,0 +1,5 @@
+---
+"@keri-ts/tufa": patch
+---
+
+Add a `tufa db dump --map-size` override for inspecting large KERIpy LMDB environments.

--- a/.changeset/tufa-nested-weighted-multisig.md
+++ b/.changeset/tufa-nested-weighted-multisig.md
@@ -1,0 +1,5 @@
+---
+"@keri-ts/tufa": patch
+---
+
+Normalize structured weighted thresholds loaded from Tufa multisig inception files and prove the public nested-group workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ At the start of each new task thread, read:
 3. Only the task-relevant topic learnings docs from that index
 4. Only the task-relevant ADRs, contracts, or plan docs those topic docs point
    to
-5. KERIpy at `$HOME/code/keri/kentbull/keripy` whenever parity or expected
+5. KERIpy at `$HOME/enc/keri/core/python/keripy` whenever parity or expected
    behavior is uncertain
 
 Then produce:

--- a/USAGE.md
+++ b/USAGE.md
@@ -17,7 +17,7 @@ finished end-user documentation.
 Run these commands from `packages/keri`:
 
 ```bash
-cd /Users/kbull/code/keri/kentbull/keri-ts/packages/keri
+cd /Users/kbull/enc/keri/core/typescript/keri-ts/packages/keri
 
 export SRC_DIR=/tmp/tufa-oobi-src
 export DST_DIR=/tmp/tufa-oobi-dst
@@ -61,7 +61,7 @@ echo "$PRE"
 Start the source-side agent server in a separate terminal:
 
 ```bash
-cd /Users/kbull/code/keri/kentbull/keri-ts/packages/keri
+cd /Users/kbull/enc/keri/core/typescript/keri-ts/packages/keri
 
 export SRC_DIR=/tmp/tufa-oobi-src
 export SRC_NAME=src
@@ -80,7 +80,7 @@ Notes:
 Back in another terminal, add mailbox authorization and generate OOBIs:
 
 ```bash
-cd /Users/kbull/code/keri/kentbull/keri-ts/packages/keri
+cd /Users/kbull/enc/keri/core/typescript/keri-ts/packages/keri
 
 export SRC_DIR=/tmp/tufa-oobi-src
 export DST_DIR=/tmp/tufa-oobi-dst
@@ -100,7 +100,7 @@ deno task tufa oobi generate -n "$SRC_NAME" --head-dir "$SRC_DIR" -a "$ALIAS" -r
 Resolve the generated OOBIs on the target side:
 
 ```bash
-cd /Users/kbull/code/keri/kentbull/keri-ts/packages/keri
+cd /Users/kbull/enc/keri/core/typescript/keri-ts/packages/keri
 
 export DST_DIR=/tmp/tufa-oobi-dst
 export DST_NAME=dst

--- a/docs/other-impls/libkeri.md
+++ b/docs/other-impls/libkeri.md
@@ -5,8 +5,8 @@ Date: 2026-03-10
 ## Scope
 
 This document captures a code-level inventory of `libkeri` in
-`/Users/kbull/code/keri/kentbull/libkeri`, using KERIpy as the authoritative
-behavioral baseline in `/Users/kbull/code/keri/kentbull/keripy`.
+`/Users/kbull/enc/keri/core/rust/hk/libkeri`, using KERIpy as the authoritative
+behavioral baseline in `/Users/kbull/enc/keri/core/python/keripy`.
 
 The focus is resolver-relevant capability:
 

--- a/docs/plans/keri/delegation-interop-handoff-2026-04-10.md
+++ b/docs/plans/keri/delegation-interop-handoff-2026-04-10.md
@@ -15,8 +15,8 @@ This document is the current source of truth for:
 ## Authority And Scope
 
 - The only authoritative KERIpy repo for this work is
-  `/Users/kbull/code/keri/kentbull/keripy` on branch `mailbox-impl`.
-- Do not use `/Users/kbull/code/keri/sam/keripy` for parity claims.
+  `/Users/kbull/enc/keri/core/python/keripy` on branch `mailbox-impl`.
+- Do not use stale or non-authoritative KERIpy checkouts for parity claims.
 - Keep the `keri-ts` delegation escrow decisions KERIpy-shaped unless there is a
   compelling reason to diverge.
 - Keep standalone mailbox-provider product support intact.
@@ -116,8 +116,8 @@ wrongly escrowed as `missingKever`.
 
 ### Files Changed
 
-- `/Users/kbull/code/keri/kentbull/keri-ts/packages/keri/src/core/eventing.ts`
-- `/Users/kbull/code/keri/kentbull/keri-ts/packages/keri/test/unit/app/gate-e-runtime.test.ts`
+- `/Users/kbull/enc/keri/core/typescript/keri-ts/packages/keri/src/core/eventing.ts`
+- `/Users/kbull/enc/keri/core/typescript/keri-ts/packages/keri/test/unit/app/gate-e-runtime.test.ts`
 
 ## Regression Added
 
@@ -128,7 +128,7 @@ Test:
 
 File:
 
-- `/Users/kbull/code/keri/kentbull/keri-ts/packages/keri/test/unit/app/gate-e-runtime.test.ts`
+- `/Users/kbull/enc/keri/core/typescript/keri-ts/packages/keri/test/unit/app/gate-e-runtime.test.ts`
 
 What it proves:
 
@@ -198,7 +198,7 @@ create failure.
 Use this pattern instead:
 
 ```sh
-cd /Users/kbull/code/keri/kentbull/keri-ts/packages/tufa
+cd /Users/kbull/enc/keri/core/typescript/keri-ts/packages/tufa
 HOME=/path/to/kli-temp-home \
 DENO_DIR=/Users/kbull/Library/Caches/deno \
 deno run --allow-all --unstable-ffi mod.ts db dump --compat \
@@ -242,21 +242,21 @@ test to time out:
 ### Focused Regression
 
 ```sh
-cd /Users/kbull/code/keri/kentbull/keri-ts
+cd /Users/kbull/enc/keri/core/typescript/keri-ts
 deno test -A packages/keri/test/unit/app/gate-e-runtime.test.ts --filter 'reopened witness `logs` queries replay remote accepted KEL state via read-through `getKever`'
 ```
 
 ### Single Interop Row
 
 ```sh
-cd /Users/kbull/code/keri/kentbull/keri-ts
+cd /Users/kbull/enc/keri/core/typescript/keri-ts
 deno test -A packages/keri/test/integration/app/interop-delegation-kli-tufa.test.ts --filter 'Interop delegation: tufa delegate with explicit proxy is approved and rotated by a KLI delegator over witness-mailbox transport with witness-backed approval discovery'
 ```
 
 ### Example Compat Dump
 
 ```sh
-cd /Users/kbull/code/keri/kentbull/keri-ts/packages/tufa
+cd /Users/kbull/enc/keri/core/typescript/keri-ts/packages/tufa
 HOME=/var/folders/kg/kzwqkdwn55j5ytz7mpbmbbjm0000gn/T/tufa-kli-home-4ad14ce7b136f5ca \
 DENO_DIR=/Users/kbull/Library/Caches/deno \
 deno run --allow-all --unstable-ffi mod.ts db dump --compat \

--- a/docs/plans/keri/lmdb-js-deno-cleanup-hook-upstream-notes.md
+++ b/docs/plans/keri/lmdb-js-deno-cleanup-hook-upstream-notes.md
@@ -87,18 +87,19 @@ should be documented and addressed as a second issue.
 
 ## Patch Mapping
 
-The local `keri-ts` patch set that corresponds to this upstream candidate is:
+The historical local `keri-ts` patch set is no longer present in the current
+checkout. Its recorded artifacts were:
 
-- [`lmdb-deno-cleanup-hook.patch`](/Users/kbull/code/keri/kentbull/keri-ts/packages/keri/scripts/patches/lmdb-deno-cleanup-hook.patch)
+- `lmdb-deno-cleanup-hook.patch`
   Adds `cleanupHookRegistered`, initializes it, guards cleanup-hook
   registration, and clears the flag in the cleanup callback.
-- [`lmdb-deno-cleanup-closeenv.patch`](/Users/kbull/code/keri/kentbull/keri-ts/packages/keri/scripts/patches/lmdb-deno-cleanup-closeenv.patch)
+- `lmdb-deno-cleanup-closeenv.patch`
   Guards `napi_remove_env_cleanup_hook(...)` behind the explicit registration
   flag.
-- [`lmdb-deno-cleanup-envwraps.patch`](/Users/kbull/code/keri/kentbull/keri-ts/packages/keri/scripts/patches/lmdb-deno-cleanup-envwraps.patch)
+- `lmdb-deno-cleanup-envwraps.patch`
   Makes `cleanupEnvWraps(void* data)` act on the exact vector pointer passed to
   the hook instead of relying on ambient thread-local state.
-- [`lmdb-deno-cleanup-envwraps-register.patch`](/Users/kbull/code/keri/kentbull/keri-ts/packages/keri/scripts/patches/lmdb-deno-cleanup-envwraps-register.patch)
+- `lmdb-deno-cleanup-envwraps-register.patch`
   Registers `cleanupEnvWraps` with `openEnvWraps` as the hook `arg` instead of
   `nullptr`.
 

--- a/packages/cesr/scripts/generate-tables.ts
+++ b/packages/cesr/scripts/generate-tables.ts
@@ -197,23 +197,10 @@ function resolveKeripyPath(): string {
   const env = Deno.env.get("KERIPY_PATH");
   if (env) return env;
 
-  const candidates = [
-    // Normalize the URL pathname by dropping only the final slash so later
-    // `${candidate}/...` joins do not produce double separators.
-    new URL("../../../../../python/keripy/", import.meta.url).pathname.replace(/\/$/, ""),
-    "/Users/kbull/code/keri/kentbull/keripy",
-  ];
-  for (const candidate of candidates) {
-    try {
-      if (Deno.statSync(`${candidate}/src/keri/core/coring.py`).isFile) {
-        return candidate;
-      }
-    } catch {
-      // Try the next known workspace layout.
-    }
-  }
-
-  return candidates[0];
+  // Normalize the URL pathname by dropping only the final slash so later
+  // `${candidate}/...` joins do not produce double separators. The relative
+  // path resolves from core/typescript/keri-ts to core/python/keripy.
+  return new URL("../../../../../python/keripy/", import.meta.url).pathname.replace(/\/$/, "");
 }
 
 async function readFile(path: string): Promise<string> {

--- a/packages/cesr/test/fixtures/keripy-primitive-vectors.ts
+++ b/packages/cesr/test/fixtures/keripy-primitive-vectors.ts
@@ -2,7 +2,7 @@
  * KERIpy `main` primitive vectors and codex constants.
  *
  * Source baseline:
- * - repo: /Users/kbull/code/keri/wot/keripy
+ * - repo: /Users/kbull/enc/keri/core/python/wot-upstream/keripy
  * - branch: main
  * - commit: 5a5597e8b7f7
  *

--- a/packages/cesr/test/unit/primitives/tholder.test.ts
+++ b/packages/cesr/test/unit/primitives/tholder.test.ts
@@ -54,6 +54,22 @@ Deno.test("tholder: hydrates nested weighted thresholds and satisfies nested gro
   assertEquals(tholder.satisfy([0, 1]), true);
 });
 
+Deno.test("tholder: nested multi-clause weighted thresholds consume slots left-to-right", () => {
+  const sith = [[{ "1": ["1/2", "1/2"] }], ["1/2", "1/2"]];
+  const tholder = new Tholder({ sith });
+  const roundTrip = new Tholder({ qb64: tholder.qb64 });
+
+  assertEquals(tholder.weighted, true);
+  assertEquals(tholder.size, 4);
+  assertEquals(tholder.sith, sith);
+  assertEquals(roundTrip.sith, sith);
+  assertEquals(tholder.satisfy([0, 1, 2, 3]), true);
+  assertEquals(tholder.satisfy([3, 2, 1, 0]), true);
+  assertEquals(tholder.satisfy([0, 1, 2]), false);
+  assertEquals(tholder.satisfy([0, 1, 3]), false);
+  assertEquals(tholder.satisfy([0, 2, 3]), false);
+});
+
 Deno.test("tholder: rejects weighted clauses whose sums do not reach one", () => {
   assertThrows(() => new Tholder({ sith: ["1/2"] }));
   assertThrows(() => new Tholder({ sith: [{ "1": ["1/2"] }] }));

--- a/packages/keri/src/app/cli/common/parsing.ts
+++ b/packages/keri/src/app/cli/common/parsing.ts
@@ -81,7 +81,7 @@ function normalizeThresholdOption(
  * modules do not duplicate threshold coercion rules.
  */
 export function parseThresholdOption(
-  value: string | undefined,
+  value: unknown,
 ): ThresholdSith | undefined {
   return normalizeThresholdOption(value);
 }

--- a/packages/keri/src/app/cli/db-dump.ts
+++ b/packages/keri/src/app/cli/db-dump.ts
@@ -26,6 +26,8 @@ type DumpArgs = {
   headDirPath?: string;
   temp?: boolean;
   compat?: boolean;
+  /** Optional LMDB map size override in bytes for large KERIpy environments. */
+  mapSize?: number;
   target?: string;
   prefix?: string;
   limit?: number;
@@ -327,10 +329,21 @@ function buildOptions(args: DumpArgs): DomainFactoryOptions {
     headDirPath: args.headDirPath,
     temp: args.temp,
     compat: args.compat,
+    mapSize: args.mapSize,
     reopen: true,
     readonly: true,
     dupsort: false,
   };
+}
+
+function resolveMapSize(rawMapSize: number | undefined): number | undefined {
+  if (rawMapSize === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(rawMapSize) || rawMapSize <= 0) {
+    throw new ValidationError("`--map-size` must be a positive integer byte count");
+  }
+  return rawMapSize;
 }
 
 function resolveLimit(rawLimit: number | undefined): number {
@@ -359,6 +372,7 @@ export function* dumpDatabase(args: Record<string, unknown>): Operation<void> {
   const headDirPath = args.headDirPath as string | undefined;
   const temp = args.temp as boolean | undefined;
   const compat = args.compat as boolean | undefined;
+  const mapSize = resolveMapSize(args.mapSize as number | undefined);
   const target = args.target as string | undefined;
   const prefix = args.prefix as string | undefined;
   const limit = resolveLimit(args.limit as number | undefined);
@@ -381,6 +395,7 @@ export function* dumpDatabase(args: Record<string, unknown>): Operation<void> {
       headDirPath,
       temp,
       compat,
+      mapSize,
     }),
   );
 
@@ -393,7 +408,9 @@ export function* dumpDatabase(args: Record<string, unknown>): Operation<void> {
       } from ${domain.path ?? "(unknown path)"}`,
     );
     console.log(
-      `Mode: readonly compat=${compat ? "true" : "false"} temp=${temp ? "true" : "false"}`,
+      `Mode: readonly compat=${compat ? "true" : "false"} temp=${temp ? "true" : "false"}${
+        mapSize !== undefined ? ` mapSize=${mapSize}` : ""
+      }`,
     );
     console.log("");
 

--- a/packages/keri/src/app/cli/multisig.ts
+++ b/packages/keri/src/app/cli/multisig.ts
@@ -128,6 +128,8 @@ function loadMultisigInceptFile(path: string): MultisigInceptFileOptions {
     ...loaded,
     aids: Array.isArray(loaded.aids) ? loaded.aids.filter(isString) : loaded.aids,
     rmids: Array.isArray(loaded.rmids) ? loaded.rmids.filter(isString) : loaded.rmids,
+    isith: parseThresholdOption(loaded.isith),
+    nsith: parseThresholdOption(loaded.nsith),
     wits: Array.isArray(loaded.wits) ? loaded.wits.filter(isString) : loaded.wits,
   };
 }

--- a/packages/keri/src/app/exchanging.ts
+++ b/packages/keri/src/app/exchanging.ts
@@ -221,7 +221,7 @@ export class Exchanger {
         essrs: this.hby.db.essrs.get([said]),
       });
 
-      if (decision.kind === "accept" || decision.kind === "reject") {
+      if (decision.kind === "reject") {
         this.removeEscrow(said);
       }
     }

--- a/packages/keri/src/app/habbing.ts
+++ b/packages/keri/src/app/habbing.ts
@@ -1902,6 +1902,34 @@ export class Habery {
     return hab;
   }
 
+  /** Commit accepted group member metadata after the corresponding group event is accepted. */
+  commitGroupHabMembers(
+    pre: string,
+    smids: readonly string[],
+    rmids: readonly string[] = smids,
+  ): void {
+    const record = this.db.getHab(pre);
+    if (!record?.mid) {
+      throw new ValidationError(`Group prefix ${pre} is missing local member metadata.`);
+    }
+    this.db.pinHab(
+      pre,
+      new HabitatRecord({
+        hid: pre,
+        name: record.name,
+        domain: record.domain,
+        mid: record.mid,
+        sid: record.sid,
+        watchers: record.watchers ? [...record.watchers] : undefined,
+        smids: [...smids],
+        rmids: [...rmids],
+      }),
+    );
+    this.ks.pinSmids(pre, this.groupMemberTuples(smids));
+    this.ks.pinRmids(pre, this.groupMemberTuples(rmids));
+    this.markAcceptedGroupHab(pre);
+  }
+
   /**
    * Rotate a locally membered group identifier from member habitat state.
    *
@@ -1979,22 +2007,9 @@ export class Habery {
       throw new ValidationError(decision.message, decision.context);
     }
 
-    if (hab.accepted) {
-      this.markAcceptedGroupHab(hab.pre);
+    if (serder.sn !== null && serder.said && this.db.kels.getLast(hab.pre, serder.sn) === serder.said) {
+      this.commitGroupHabMembers(hab.pre, signingMembers, rotationMembers);
     }
-    this.ks.pinSmids(hab.pre, this.groupMemberTuples(signingMembers));
-    this.ks.pinRmids(hab.pre, this.groupMemberTuples(rotationMembers));
-    this.db.pinHab(
-      hab.pre,
-      new HabitatRecord({
-        hid: hab.pre,
-        name: group,
-        domain: record.domain,
-        mid: record.mid,
-        smids: [...signingMembers],
-        rmids: [...rotationMembers],
-      }),
-    );
 
     return {
       hab,

--- a/packages/keri/src/app/multisig-workflows.ts
+++ b/packages/keri/src/app/multisig-workflows.ts
@@ -435,6 +435,10 @@ function* approveKelProposal(
 
   const deliveries = yield* publishProposal(runtime, member, members, route, label, payload, localMessage);
   const accepted = eventAccepted(hby, serder);
+  if (accepted && (route === MULTISIG_ICP_ROUTE || route === MULTISIG_ROT_ROUTE)) {
+    const rmids = stringArrayField(payload, "rmids");
+    hby.commitGroupHabMembers(groupPre, smids, rmids.length > 0 ? rmids : smids);
+  }
 
   return { route, said: wrapperSaid, embedded: embeddedSaid ?? "", group: groupPre, accepted, deliveries };
 }

--- a/packages/keri/src/db/core/lmdber.ts
+++ b/packages/keri/src/db/core/lmdber.ts
@@ -107,6 +107,15 @@ export interface LMDBerOptions extends PathManagerOptions {
   readonly?: boolean;
   dupsort?: boolean;
   logger?: Logger;
+  /**
+   * Requested LMDB map size in bytes.
+   *
+   * When opening an existing environment, the effective map size is raised to
+   * at least the map size stored in `data.mdb` so KERIpy databases created with
+   * large `KERI_*_MAP_SIZE` values (for example 10 GiB) can be opened without a
+   * native abort from undersized virtual mapping.
+   */
+  mapSize?: number;
 }
 
 /** Defaultable LMDB/path settings shared by all `LMDBer` instances. */
@@ -130,8 +139,106 @@ export const LMDBER_DEFAULTS: LMDBerDefaults = {
   mode: "r+",
   fext: "text",
   maxNamedDBs: 96,
-  mapSize: 4 * 1024 * 1024 * 1024, // 4GB default
+  // 10 GiB default so common KERIpy deployments (e.g. KERI_BASER_MAP_SIZE=10GiB)
+  // open without an explicit CLI/env override. Existing environments still
+  // auto-raise to at least the map size stamped in `data.mdb` when larger.
+  mapSize: 10 * 1024 * 1024 * 1024,
 };
+
+/** LMDB page size used when validating map sizes read from existing files. */
+const LMDB_PAGE_SIZE = 4096;
+/** Reject absurd header values rather than mapping terabytes of address space. */
+const LMDB_MAP_SIZE_MAX = 1024 * 1024 * 1024 * 1024; // 1 TiB
+/**
+ * Floor applied when an existing `data.mdb` is present but its stored map size
+ * cannot be parsed. Covers common KERIpy production values such as 10 GiB.
+ */
+const EXISTING_DB_MAP_SIZE_FLOOR = 16 * 1024 * 1024 * 1024; // 16 GiB
+
+/**
+ * Read the map size stamped into an existing LMDB `data.mdb` meta page.
+ *
+ * Returns null when the file is missing, too small, or the candidate map size
+ * fails basic sanity checks (page alignment and range).
+ */
+export function readStoredLmdbMapSize(dataMdbPath: string): number | null {
+  try {
+    const file = Deno.openSync(dataMdbPath, { read: true });
+    try {
+      const header = new Uint8Array(40);
+      const bytesRead = file.readSync(header);
+      if (bytesRead === null || bytesRead < 40) {
+        return null;
+      }
+      // On current LMDB data-v1 layouts used with keri-ts/KERIpy, me_mapsize is
+      // a little-endian uint64 at offset 32 in the first meta page.
+      const view = new DataView(header.buffer, header.byteOffset, header.byteLength);
+      const mapSize = Number(view.getBigUint64(32, true));
+      if (
+        !Number.isFinite(mapSize)
+        || mapSize < LMDB_PAGE_SIZE
+        || mapSize > LMDB_MAP_SIZE_MAX
+        || mapSize % LMDB_PAGE_SIZE !== 0
+      ) {
+        return null;
+      }
+      return mapSize;
+    } finally {
+      file.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the map size used for `lmdb.open`.
+ *
+ * Precedence for the configured size:
+ * 1. explicit option
+ * 2. `KERI_LMDB_MAP_SIZE`
+ * 3. `KERI_BASER_MAP_SIZE` (KERIpy-compatible alias used by witness deployments)
+ * 4. library default
+ *
+ * Existing environments then raise the effective size to at least the map size
+ * stored in `data.mdb` (or a conservative floor when the header is unreadable).
+ */
+export function resolveLmdbMapSize(args: {
+  optionMapSize?: number;
+  envMapSize?: string | null;
+  baserEnvMapSize?: string | null;
+  defaultMapSize: number;
+  dataMdbPath?: string | null;
+  databaseExists: boolean;
+}): number {
+  const parseEnv = (raw: string | null | undefined): number | undefined => {
+    if (raw === undefined || raw === null || raw.trim() === "") {
+      return undefined;
+    }
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return undefined;
+    }
+    return parsed;
+  };
+
+  const configured = args.optionMapSize
+    ?? parseEnv(args.envMapSize)
+    ?? parseEnv(args.baserEnvMapSize)
+    ?? args.defaultMapSize;
+
+  if (!args.databaseExists) {
+    return configured;
+  }
+
+  const stored = args.dataMdbPath
+    ? readStoredLmdbMapSize(args.dataMdbPath)
+    : null;
+  if (stored !== null) {
+    return Math.max(configured, stored);
+  }
+  return Math.max(configured, EXISTING_DB_MAP_SIZE_FLOOR);
+}
 
 const DEFAULT_DB_VERSION = "1.0.0";
 
@@ -164,6 +271,8 @@ export class LMDBer {
   public readonly: boolean;
   private defaults: LMDBerDefaults;
   private readonly logger: Logger;
+  /** Optional constructor-level map size override applied on every reopen. */
+  private configuredMapSize?: number;
 
   // Class constants
   static readonly HeadDirPath: string = "/usr/local/var";
@@ -181,6 +290,7 @@ export class LMDBer {
   constructor(options: LMDBerOptions = {}, defaults?: Partial<LMDBerDefaults>) {
     this.defaults = { ...LMDBER_DEFAULTS, ...defaults };
     this.logger = options.logger ?? consoleLogger;
+    this.configuredMapSize = options.mapSize;
 
     // Create PathManager with composition
     const pathDefaults: Partial<PathManagerDefaults> = {
@@ -296,12 +406,6 @@ export class LMDBer {
     }
     let dbPath = this.pathManager.path;
 
-    // Get map size from environment variable or use default
-    const mapSizeEnv = Deno.env.get("KERI_LMDB_MAP_SIZE");
-    const mapSize = mapSizeEnv
-      ? parseInt(mapSizeEnv, 10)
-      : this.defaults.mapSize;
-
     // Check if database files exist before opening
     const dbExists = yield* this.checkDatabaseExists();
 
@@ -315,13 +419,22 @@ export class LMDBer {
       return false;
     }
 
-    // For readonly opens of existing databases, use a large mapSize that's safe
-    // LMDB will use the actual map size from the database file, but the Node.js
-    // lmdb package requires mapSize to be >= the database's actual map size
-    // Use 4GB (KERIpy default) or larger to ensure compatibility
-    const effectiveMapSize = readonly && dbExists
-      ? Math.max(mapSize, 4 * 1024 * 1024 * 1024) // At least 4GB for existing databases
-      : mapSize;
+    // Prefer reopen-time option, then constructor option, then env, then default.
+    // When data.mdb already exists, raise to at least the stored map size so
+    // KERIpy databases opened with KERI_BASER_MAP_SIZE=10GiB (etc.) do not abort
+    // under an undersized lmdb-js virtual mapping.
+    if (options.mapSize !== undefined) {
+      this.configuredMapSize = options.mapSize;
+    }
+    const dataMdbPath = dbExists ? `${dbPath}/data.mdb` : null;
+    const effectiveMapSize = resolveLmdbMapSize({
+      optionMapSize: this.configuredMapSize,
+      envMapSize: Deno.env.get("KERI_LMDB_MAP_SIZE"),
+      baserEnvMapSize: Deno.env.get("KERI_BASER_MAP_SIZE"),
+      defaultMapSize: this.defaults.mapSize,
+      dataMdbPath,
+      databaseExists: dbExists,
+    });
     const dbConfig = {
       path: dbPath, // Use directory path (Node.js lmdb should handle this)
       maxDbs: this.defaults.maxNamedDBs,

--- a/packages/keri/src/did/webs/documenting.ts
+++ b/packages/keri/src/did/webs/documenting.ts
@@ -5,6 +5,7 @@
  * state, and active designated-alias credentials. Hosted artifacts may use
  * `did:web`, but resolver comparison normalizes them back to `did:webs`.
  */
+import type { ThresholdClause, ThresholdClauseEntry, ThresholdSith } from "../../../../cesr/mod.ts";
 import type { AgentRuntime } from "../../app/agent-runtime.ts";
 import type { Habery } from "../../app/habbing.ts";
 import { ValidationError } from "../../core/errors.ts";
@@ -26,6 +27,13 @@ export interface DidDocument extends Record<string, unknown> {
 export interface DidDocumentOptions {
   readonly hosted?: boolean;
   readonly metadata?: boolean;
+}
+
+type VerificationMethodEntry = Record<string, unknown> & { id: string };
+
+interface Rational {
+  readonly numerator: bigint;
+  readonly denominator: bigint;
 }
 
 /** Generate a DID document or DID Resolution Result from runtime state. */
@@ -105,7 +113,7 @@ export function didResolutionError(
 function verificationMethods(
   did: string,
   kever: Kever,
-): Array<Record<string, unknown> & { id: string }> {
+): VerificationMethodEntry[] {
   return kever.verfers.map((verfer) => ({
     id: `#${verfer.qb64}`,
     type: "JsonWebKey",
@@ -123,7 +131,7 @@ function thresholdVerificationMethods(
   did: string,
   kever: Kever,
   methodIds: readonly string[],
-): Array<Record<string, unknown> & { id: string }> {
+): VerificationMethodEntry[] {
   const tholder = kever.tholder;
   if (!tholder || methodIds.length === 0) {
     return [];
@@ -140,13 +148,7 @@ function thresholdVerificationMethods(
       conditionThreshold: [...methodIds],
     }];
   }
-  return [{
-    id: `#${kever.prefixer.qb64}`,
-    type: "ConditionalProof2022",
-    controller: did,
-    threshold: tholder.sith,
-    conditionWeightedThreshold: weightedConditions(tholder.sith, methodIds),
-  }];
+  return weightedThresholdVerificationMethods(did, kever.prefixer.qb64, tholder.sith, methodIds);
 }
 
 function serviceEntries(
@@ -240,24 +242,220 @@ function pruneEmpty(value: Record<string, unknown>): Record<string, unknown> {
   return result;
 }
 
-function weightedConditions(
-  threshold: unknown,
-  methodIds: readonly string[],
-): Array<Record<string, unknown>> {
-  if (!Array.isArray(threshold) || threshold.length === 0) {
-    return methodIds.map((id) => ({ condition: id, weight: 1 }));
-  }
-  const weights = Array.isArray(threshold[0]) ? threshold[0] : threshold;
-  return methodIds.map((id, index) => ({
-    condition: id,
-    weight: weights[index] ?? 1,
-  }));
-}
-
 function base64Url(raw: Uint8Array): string {
   let text = "";
   for (const byte of raw) {
     text += String.fromCharCode(byte);
   }
   return btoa(text).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+function weightedThresholdVerificationMethods(
+  did: string,
+  pre: string,
+  sith: ThresholdSith,
+  methodIds: readonly string[],
+): VerificationMethodEntry[] {
+  if (typeof sith === "string") {
+    throw new ValidationError(`Expected weighted threshold for ${pre}.`);
+  }
+  const clauses = thresholdClauses(sith);
+  if (clauses.length === 1) {
+    const projected = projectWeightedClause({
+      id: `#${pre}`,
+      did,
+      pre,
+      clause: clauses[0]!,
+      clauseIndex: 0,
+      methodIds,
+      startSlot: 0,
+    });
+    return [projected.method, ...projected.children];
+  }
+
+  const methods: VerificationMethodEntry[] = [];
+  const conditionAnd: string[] = [];
+  let slot = 0;
+  for (const [clauseIndex, clause] of clauses.entries()) {
+    const projected = projectWeightedClause({
+      id: `#${pre}-kt-c${clauseIndex}`,
+      did,
+      pre,
+      clause,
+      clauseIndex,
+      methodIds,
+      startSlot: slot,
+    });
+    conditionAnd.push(projected.method.id);
+    methods.push(projected.method, ...projected.children);
+    slot = projected.nextSlot;
+  }
+
+  return [{
+    id: `#${pre}`,
+    type: "ConditionalProof2022",
+    controller: did,
+    conditionAnd,
+  }, ...methods];
+}
+
+function thresholdClauses(sith: Exclude<ThresholdSith, string>): ThresholdClause[] {
+  if (!Array.isArray(sith) || sith.length === 0) {
+    throw new ValidationError("Weighted threshold must be a non-empty array.");
+  }
+  return sith.some((entry) => !Array.isArray(entry))
+    ? [sith as ThresholdClause]
+    : sith as ThresholdClause[];
+}
+
+function projectWeightedClause(args: {
+  id: string;
+  did: string;
+  pre: string;
+  clause: ThresholdClause;
+  clauseIndex: number;
+  methodIds: readonly string[];
+  startSlot: number;
+}): {
+  method: VerificationMethodEntry;
+  children: VerificationMethodEntry[];
+  nextSlot: number;
+} {
+  const topWeights = args.clause.map(clauseEntryWeight);
+  const scaled = scaleWeights(topWeights);
+  const children: VerificationMethodEntry[] = [];
+  const conditionWeightedThreshold: Array<{ condition: string; weight: number }> = [];
+  let slot = args.startSlot;
+  let groupIndex = 0;
+
+  for (const [entryIndex, entry] of args.clause.entries()) {
+    if (typeof entry === "string") {
+      conditionWeightedThreshold.push({
+        condition: methodIdAt(args.methodIds, slot),
+        weight: scaled.weights[entryIndex]!,
+      });
+      slot += 1;
+      continue;
+    }
+
+    const [, members] = singleWeightedGroup(entry);
+    const nestedWeights = members.map(parseWeight);
+    const nestedScaled = scaleWeights(nestedWeights);
+    const nestedConditions = members.map((_member, memberIndex) => ({
+      condition: methodIdAt(args.methodIds, slot + memberIndex),
+      weight: nestedScaled.weights[memberIndex]!,
+    }));
+    slot += members.length;
+
+    const childId = `#${args.pre}-kt-c${args.clauseIndex}-g${groupIndex}`;
+    groupIndex += 1;
+    children.push({
+      id: childId,
+      type: "ConditionalProof2022",
+      controller: args.did,
+      threshold: nestedScaled.threshold,
+      conditionWeightedThreshold: nestedConditions,
+    });
+    conditionWeightedThreshold.push({
+      condition: childId,
+      weight: scaled.weights[entryIndex]!,
+    });
+  }
+
+  return {
+    method: {
+      id: args.id,
+      type: "ConditionalProof2022",
+      controller: args.did,
+      threshold: scaled.threshold,
+      conditionWeightedThreshold,
+    },
+    children,
+    nextSlot: slot,
+  };
+}
+
+function clauseEntryWeight(entry: ThresholdClauseEntry): Rational {
+  if (typeof entry === "string") {
+    return parseWeight(entry);
+  }
+  const [weight] = singleWeightedGroup(entry);
+  return parseWeight(weight);
+}
+
+function singleWeightedGroup(entry: Record<string, string[]>): [string, string[]] {
+  const keys = Object.keys(entry);
+  if (keys.length !== 1) {
+    throw new ValidationError("Nested weighted threshold groups must have exactly one key.");
+  }
+  const weight = keys[0]!;
+  const members = entry[weight];
+  if (!Array.isArray(members) || members.length === 0) {
+    throw new ValidationError("Nested weighted threshold groups must contain member weights.");
+  }
+  return [weight, members];
+}
+
+function methodIdAt(methodIds: readonly string[], index: number): string {
+  const methodId = methodIds[index];
+  if (!methodId) {
+    throw new ValidationError(`Weighted threshold references missing signer slot ${index}.`);
+  }
+  return methodId;
+}
+
+function parseWeight(input: string): Rational {
+  const text = input.trim();
+  if (/^\d+$/.test(text)) {
+    return normalizeRational(BigInt(text), 1n);
+  }
+  const match = text.match(/^(\d+)\/(\d+)$/);
+  if (!match) {
+    throw new ValidationError(`Invalid threshold weight ${input}.`);
+  }
+  return normalizeRational(BigInt(match[1]!), BigInt(match[2]!));
+}
+
+function scaleWeights(weights: readonly Rational[]): { threshold: number; weights: number[] } {
+  let common = 1n;
+  for (const weight of weights) {
+    common = lcm(common, weight.denominator);
+  }
+  return {
+    threshold: safeNumber(common),
+    weights: weights.map((weight) => safeNumber(weight.numerator * (common / weight.denominator))),
+  };
+}
+
+function normalizeRational(numerator: bigint, denominator: bigint): Rational {
+  if (denominator === 0n) {
+    throw new ValidationError("Invalid threshold weight denominator=0.");
+  }
+  const divisor = gcd(numerator, denominator);
+  return {
+    numerator: numerator / divisor,
+    denominator: denominator / divisor,
+  };
+}
+
+function gcd(left: bigint, right: bigint): bigint {
+  let a = left < 0n ? -left : left;
+  let b = right < 0n ? -right : right;
+  while (b !== 0n) {
+    const next = a % b;
+    a = b;
+    b = next;
+  }
+  return a === 0n ? 1n : a;
+}
+
+function lcm(left: bigint, right: bigint): bigint {
+  return (left / gcd(left, right)) * right;
+}
+
+function safeNumber(value: bigint): number {
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new ValidationError(`Threshold weight scale ${value} exceeds safe JSON number range.`);
+  }
+  return Number(value);
 }

--- a/packages/keri/test/unit/app/exchanging.test.ts
+++ b/packages/keri/test/unit/app/exchanging.test.ts
@@ -232,3 +232,107 @@ Deno.test("Exchanger replays partial-signature escrows once the missing signatur
     }
   });
 });
+
+Deno.test("Exchanger accepts nested weighted threshold combinations from partial escrow", async () => {
+  await run(function*() {
+    const hby = yield* createHabery({
+      name: `exchange-nested-escrow-${crypto.randomUUID()}`,
+      temp: true,
+      skipConfig: true,
+    });
+    try {
+      const sender = hby.makeHab("sender", undefined, {
+        transferable: true,
+        icount: 3,
+        isith: [{ "1": ["1/2", "1/2"] }, "1"],
+        ncount: 3,
+        nsith: [{ "1": ["1/2", "1/2"] }, "1"],
+        toad: 0,
+      });
+      const recipient = hby.makeHab("recipient", undefined, {
+        transferable: true,
+        icount: 1,
+        isith: "1",
+        ncount: 1,
+        nsith: "1",
+        toad: 0,
+      });
+
+      const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+      ingestKeriBytes(runtime, sender.makeLocScheme("http://127.0.0.1:9021"));
+      ingestKeriBytes(
+        runtime,
+        sender.makeEndRole(sender.pre, EndpointRoles.controller, true),
+      );
+      ingestKeriBytes(
+        runtime,
+        recipient.makeLocScheme("http://127.0.0.1:9022"),
+      );
+      ingestKeriBytes(
+        runtime,
+        recipient.makeEndRole(recipient.pre, EndpointRoles.controller, true),
+      );
+      yield* processRuntimeTurn(runtime, { hab: sender });
+
+      const exchanger = new Exchanger(hby);
+      loadChallengeHandlers(hby.db, exchanger);
+      const serder = makeExchangeSerder(
+        "/challenge/response",
+        { i: sender.pre, words: ["gaga", "haha"] },
+        { sender: sender.pre, recipient: recipient.pre },
+      );
+      const sigers = sender.sign(serder.raw, true);
+      const group = new TransIdxSigGroup(
+        new Prefixer({ qb64: sender.pre }),
+        sender.kever!.sner,
+        new Diger({ qb64: sender.kever!.said }),
+        sigers,
+      );
+
+      const initial = exchanger.processEvent({
+        serder,
+        tsgs: [
+          new TransIdxSigGroup(group.prefixer, group.seqner, group.diger, [
+            sigers[0],
+          ]),
+        ],
+      });
+      const said = serder.said;
+      assertExists(said);
+      assertEquals(initial.kind, "escrow");
+      assertExists(hby.db.epse.get([said]));
+
+      const quadKey = [said, group.pre, group.snh, group.said] as const;
+      hby.db.esigs.add(quadKey, sigers[1]);
+      exchanger.processEscrows();
+
+      assertEquals(hby.db.epse.get([said]), null);
+      assertEquals(hby.db.exns.get([said])?.said, said);
+      assertEquals(
+        [...hby.db.esigs.getTopItemIter([said, ""])].map(([, siger]) => siger.index),
+        [0, 1],
+      );
+      assertEquals(exchanger.lead(sender, said), true);
+
+      const alternate = makeExchangeSerder(
+        "/challenge/response",
+        { i: sender.pre, words: ["jaja", "kaka"] },
+        { sender: sender.pre, recipient: recipient.pre },
+      );
+      const alternateSigers = sender.sign(alternate.raw, true);
+      const accepted = exchanger.processEvent({
+        serder: alternate,
+        tsgs: [
+          new TransIdxSigGroup(group.prefixer, group.seqner, group.diger, [
+            alternateSigers[2],
+          ]),
+        ],
+      });
+      assertExists(alternate.said);
+      assertEquals(accepted.kind, "accept");
+      assertEquals(hby.db.exns.get([alternate.said])?.said, alternate.said);
+    } finally {
+      yield* hby.close(true);
+    }
+  });
+});

--- a/packages/keri/test/unit/app/habbing.test.ts
+++ b/packages/keri/test/unit/app/habbing.test.ts
@@ -25,7 +25,7 @@ import {
   Verfer,
   Vrsn_2_0,
 } from "../../../../cesr/mod.ts";
-import { createAgentRuntime } from "../../../src/app/agent-runtime.ts";
+import { createAgentRuntime, ingestKeriBytes, processRuntimeTurn } from "../../../src/app/agent-runtime.ts";
 import { createConfiger } from "../../../src/app/configing.ts";
 import { Anchorer, DELEGATE_REQUEST_ROUTE } from "../../../src/app/delegating.ts";
 import type { Poster } from "../../../src/app/forwarding.ts";
@@ -956,6 +956,93 @@ Deno.test("Habery makeGroupHab creates a local group inception and persists memb
         ],
       );
     } finally {
+      yield* hby.close(true);
+    }
+  });
+});
+
+Deno.test("Habery rotateGroupHab preserves accepted member metadata while rotation is pending", async () => {
+  await run(function*() {
+    const hby = yield* createHabery({
+      name: `habery-group-pending-rot-${crypto.randomUUID()}`,
+      temp: true,
+    });
+    const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+    const remoteHby = yield* createHabery({
+      name: `habery-group-pending-rot-remote-${crypto.randomUUID()}`,
+      temp: true,
+    });
+    try {
+      const member1 = hby.makeHab("member1", undefined, {
+        transferable: true,
+        icount: 1,
+        isith: "1",
+        ncount: 1,
+        nsith: "1",
+        toad: 0,
+      });
+      const member2 = hby.makeHab("member2", undefined, {
+        transferable: true,
+        icount: 1,
+        isith: "1",
+        ncount: 1,
+        nsith: "1",
+        toad: 0,
+      });
+      const remote = remoteHby.makeHab("remote", undefined, {
+        transferable: true,
+        icount: 1,
+        isith: "1",
+        ncount: 1,
+        nsith: "1",
+        toad: 0,
+      });
+      for (const message of remoteHby.db.clonePreIter(remote.pre, 0)) {
+        ingestKeriBytes(runtime, message);
+      }
+      yield* processRuntimeTurn(runtime, { pollMailbox: false });
+      assertExists(hby.db.getKever(remote.pre));
+
+      const group = hby.makeGroupHab(
+        "team",
+        member1,
+        [member1.pre, member2.pre],
+        [member1.pre, member2.pre],
+        undefined,
+        {
+          isith: "2",
+          nsith: "2",
+          toad: 0,
+        },
+      );
+      assertEquals(hby.db.getHab(group.hab.pre)?.smids, [member1.pre, member2.pre]);
+      assertEquals(hby.db.getHab(group.hab.pre)?.rmids, [member1.pre, member2.pre]);
+
+      hby.habs.delete(member2.pre);
+      const rotation = hby.rotateGroupHab(
+        "team",
+        [member1.pre, member2.pre],
+        [member1.pre, remote.pre],
+        {
+          isith: "2",
+          nsith: "2",
+          toad: 0,
+        },
+      );
+
+      assertEquals(rotation.sigers.map((siger) => siger.index), [0]);
+      assertEquals(
+        rotation.serder.sn !== null ? hby.db.kels.getLast(group.hab.pre, rotation.serder.sn) : null,
+        null,
+      );
+      const stored = hby.db.getHab(group.hab.pre);
+      assertEquals(stored?.smids, [member1.pre, member2.pre]);
+      assertEquals(stored?.rmids, [member1.pre, member2.pre]);
+      assertEquals(hby.ks.getSmids(group.hab.pre).map((tuple) => tuple[0].qb64), [member1.pre, member2.pre]);
+      assertEquals(hby.ks.getRmids(group.hab.pre).map((tuple) => tuple[0].qb64), [member1.pre, member2.pre]);
+    } finally {
+      yield* remoteHby.close(true);
+      yield* runtime.close();
       yield* hby.close(true);
     }
   });

--- a/packages/keri/test/unit/app/ipexing.test.ts
+++ b/packages/keri/test/unit/app/ipexing.test.ts
@@ -225,3 +225,67 @@ Deno.test("accepted IPEX grants create KERIpy-shaped notifier entries", async ()
     }
   });
 });
+
+Deno.test("IPEX grants accept nested weighted threshold combinations from partial escrow", async () => {
+  await run(function*() {
+    const hby = yield* createHabery({
+      name: `ipex-nested-escrow-${crypto.randomUUID()}`,
+      temp: true,
+      skipConfig: true,
+    });
+    try {
+      const sender = hby.makeHab("sender", undefined, {
+        transferable: true,
+        icount: 3,
+        isith: [{ "1": ["1/2", "1/2"] }, "1"],
+        ncount: 3,
+        nsith: [{ "1": ["1/2", "1/2"] }, "1"],
+        toad: 0,
+      });
+      const recipient = hby.makeHab("recipient", undefined, {
+        transferable: true,
+        icount: 1,
+        isith: "1",
+        ncount: 1,
+        nsith: "1",
+        toad: 0,
+      });
+      const exchanger = new Exchanger(hby);
+      loadIpexHandlers(hby, exchanger);
+      const acdc = exchangeMessage("/dummy/acdc", { d: "data" }, { sender: sender.pre })[0];
+      const [grant] = ipexGrantExn(sender, recipient.pre, "grant message", acdc);
+      const sigers = sender.sign(grant.raw, true);
+      const group = new TransIdxSigGroup(
+        new Prefixer({ qb64: sender.pre }),
+        sender.kever!.sner,
+        new Diger({ qb64: sender.kever!.said }),
+        sigers,
+      );
+
+      const initial = exchanger.processEvent({
+        serder: grant,
+        tsgs: [
+          new TransIdxSigGroup(group.prefixer, group.seqner, group.diger, [
+            sigers[0],
+          ]),
+        ],
+      });
+      assertExists(grant.said);
+      assertEquals(initial.kind, "escrow");
+      assertExists(hby.db.epse.get([grant.said]));
+
+      const quadKey = [grant.said, group.pre, group.snh, group.said] as const;
+      hby.db.esigs.add(quadKey, sigers[1]);
+      exchanger.processEscrows();
+
+      assertEquals(hby.db.epse.get([grant.said]), null);
+      assertEquals(hby.db.exns.get([grant.said])?.said, grant.said);
+      assertEquals(
+        [...hby.db.esigs.getTopItemIter([grant.said, ""])].map(([, siger]) => siger.index),
+        [0, 1],
+      );
+    } finally {
+      yield* hby.close(true);
+    }
+  });
+});

--- a/packages/keri/test/unit/app/parsing.test.ts
+++ b/packages/keri/test/unit/app/parsing.test.ts
@@ -1,7 +1,10 @@
 // @file-test-lane app-fast-parallel
 
 import { assertEquals } from "jsr:@std/assert";
-import { parseExnDataItems } from "../../../src/app/cli/common/parsing.ts";
+import {
+  parseExnDataItems,
+  parseThresholdOption,
+} from "../../../src/app/cli/common/parsing.ts";
 
 Deno.test("parseExnDataItems matches KERIpy-style coercion and merge order", () => {
   const parsed = parseExnDataItems([
@@ -45,4 +48,15 @@ Deno.test("parseExnDataItems loads object payloads from @file references", () =>
   } finally {
     Deno.removeSync(dir, { recursive: true });
   }
+});
+
+Deno.test("parseThresholdOption accepts CLI and JSON-file threshold forms", () => {
+  const structured = [{ "1": ["1/2", "1/2"] }, "1"];
+
+  assertEquals(parseThresholdOption(2), "2");
+  assertEquals(parseThresholdOption("2"), "2");
+  assertEquals(parseThresholdOption(JSON.stringify(structured)), structured);
+  assertEquals(parseThresholdOption(structured), structured);
+  assertEquals(parseThresholdOption(undefined), undefined);
+  assertEquals(parseThresholdOption(null), undefined);
 });

--- a/packages/keri/test/unit/db/core/lmdber-map-size.test.ts
+++ b/packages/keri/test/unit/db/core/lmdber-map-size.test.ts
@@ -1,0 +1,83 @@
+// @file-test-lane db-fast
+
+import { assertEquals } from "jsr:@std/assert";
+import {
+  readStoredLmdbMapSize,
+  resolveLmdbMapSize,
+} from "../../../../src/db/core/lmdber.ts";
+
+Deno.test("db/core lmdber map size - resolve prefers option, then env aliases, then default", () => {
+  assertEquals(
+    resolveLmdbMapSize({
+      optionMapSize: 111,
+      envMapSize: "222",
+      baserEnvMapSize: "333",
+      defaultMapSize: 444,
+      databaseExists: false,
+    }),
+    111,
+  );
+  assertEquals(
+    resolveLmdbMapSize({
+      envMapSize: "222",
+      baserEnvMapSize: "333",
+      defaultMapSize: 444,
+      databaseExists: false,
+    }),
+    222,
+  );
+  assertEquals(
+    resolveLmdbMapSize({
+      baserEnvMapSize: "333",
+      defaultMapSize: 444,
+      databaseExists: false,
+    }),
+    333,
+  );
+  assertEquals(
+    resolveLmdbMapSize({
+      defaultMapSize: 444,
+      databaseExists: false,
+    }),
+    444,
+  );
+});
+
+Deno.test("db/core lmdber map size - existing DB raises to stored header map size", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "lmdber-mapsize-" });
+  const dataMdbPath = `${dir}/data.mdb`;
+  try {
+    const header = new Uint8Array(40);
+    const view = new DataView(header.buffer);
+    const stored = 10 * 1024 * 1024 * 1024;
+    view.setBigUint64(32, BigInt(stored), true);
+    await Deno.writeFile(dataMdbPath, header);
+
+    assertEquals(readStoredLmdbMapSize(dataMdbPath), stored);
+    // Default/configured 10 GiB matches a 10 GiB stored header; larger stored
+    // sizes still win via Math.max in resolveLmdbMapSize.
+    assertEquals(
+      resolveLmdbMapSize({
+        optionMapSize: 10 * 1024 * 1024 * 1024,
+        defaultMapSize: 10 * 1024 * 1024 * 1024,
+        dataMdbPath,
+        databaseExists: true,
+      }),
+      stored,
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => undefined);
+  }
+});
+
+Deno.test("db/core lmdber map size - existing DB without readable header uses floor", () => {
+  assertEquals(
+    resolveLmdbMapSize({
+      optionMapSize: 1024,
+      defaultMapSize: 1024,
+      dataMdbPath: "/tmp/does-not-exist-lmdber-mapsize.data.mdb",
+      databaseExists: true,
+    }),
+    16 * 1024 * 1024 * 1024,
+  );
+});

--- a/packages/keri/test/unit/did/webs.test.ts
+++ b/packages/keri/test/unit/did/webs.test.ts
@@ -1,7 +1,7 @@
 // @file-test-lane app-fast-parallel
 
 import { run } from "effection";
-import { assertEquals, assertThrows } from "jsr:@std/assert";
+import { assertEquals, assertExists, assertThrows } from "jsr:@std/assert";
 import { createAgentRuntime, ingestKeriBytes, processRuntimeTurn } from "../../../src/app/agent-runtime.ts";
 import { dwsGenerateCommand } from "../../../src/app/cli/did.ts";
 import { createHabery } from "../../../src/app/habbing.ts";
@@ -11,6 +11,7 @@ import {
   DEFAULT_DESIGNATED_ALIASES_REGISTRY_NAME,
   DESIGNATED_ALIASES_SCHEMA_SAID,
   didWebsArtifactUrls,
+  generateBareDidDocument,
   generateDidWebsArtifacts,
   listActiveDesignatedAliasCredentials,
   parseDid,
@@ -201,6 +202,221 @@ Deno.test("did/webs - keri.cesr replays controller KEL once and appends DA mater
       assertEquals(keriCesr.includes("\"v\":\"ACDC"), true);
       assertEquals(keriCesr.includes("\"r\":\"/loc/scheme\""), true);
       assertEquals(keriCesr.includes("\"role\":\"mailbox\""), true);
+    } finally {
+      yield* runtime.close();
+      yield* hby.close(true);
+    }
+  });
+});
+
+type VerificationMethodDocument = Record<string, unknown> & {
+  id: string;
+  type?: string;
+  threshold?: unknown;
+  conditionThreshold?: unknown;
+  conditionWeightedThreshold?: unknown;
+  conditionAnd?: unknown;
+  conditionOr?: unknown;
+};
+
+function didFor(pre: string): string {
+  return `did:webs:example.com:dws:${pre}`;
+}
+
+function verificationMethodMap(document: Record<string, unknown>): Map<string, VerificationMethodDocument> {
+  const methods = document.verificationMethod;
+  if (!Array.isArray(methods)) {
+    throw new Error("Expected verificationMethod array.");
+  }
+  return new Map(methods.map((method) => {
+    if (!method || typeof method !== "object" || typeof (method as { id?: unknown }).id !== "string") {
+      throw new Error("Expected verification method with id.");
+    }
+    return [(method as { id: string }).id, method as VerificationMethodDocument];
+  }));
+}
+
+function requireVerificationMethod(
+  methods: Map<string, VerificationMethodDocument>,
+  id: string,
+): VerificationMethodDocument {
+  const method = methods.get(id);
+  assertExists(method);
+  return method;
+}
+
+function assertOnlyConditionFamily(method: VerificationMethodDocument): void {
+  const families = [
+    "conditionThreshold",
+    "conditionWeightedThreshold",
+    "conditionAnd",
+    "conditionOr",
+  ].filter((key) => key in method);
+  assertEquals(families.length, 1, method.id);
+  assertEquals("path" in method, false, method.id);
+  assertEquals(Array.isArray(method.threshold), false, method.id);
+  assertEquals(
+    method.threshold !== null && typeof method.threshold === "object",
+    false,
+    method.id,
+  );
+}
+
+function assertConditionalProofMethods(document: Record<string, unknown>): void {
+  for (const method of verificationMethodMap(document).values()) {
+    if (method.type === "ConditionalProof2022") {
+      assertOnlyConditionFamily(method);
+    }
+  }
+}
+
+Deno.test("did/webs - numeric thresholds project as conditionThreshold methods", async () => {
+  await run(function*() {
+    const hby = yield* createHabery({
+      name: `did-webs-numeric-${crypto.randomUUID()}`,
+      temp: true,
+    });
+    const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+    try {
+      const hab = hby.makeHab("numeric", undefined, {
+        transferable: true,
+        icount: 2,
+        isith: "2",
+        ncount: 2,
+        nsith: "2",
+        toad: 0,
+      });
+      const document = generateBareDidDocument(runtime, didFor(hab.pre));
+      const methods = verificationMethodMap(document);
+      const keyMethods = hab.kever!.verfers.map((verfer) => `#${verfer.qb64}`);
+      const root = requireVerificationMethod(methods, `#${hab.pre}`);
+
+      assertEquals(root.type, "ConditionalProof2022");
+      assertEquals(root.threshold, 2);
+      assertEquals(root.conditionThreshold, keyMethods);
+      assertConditionalProofMethods(document);
+    } finally {
+      yield* runtime.close();
+      yield* hby.close(true);
+    }
+  });
+});
+
+Deno.test("did/webs - flat weighted thresholds project with scaled integer weights", async () => {
+  await run(function*() {
+    const hby = yield* createHabery({
+      name: `did-webs-flat-weighted-${crypto.randomUUID()}`,
+      temp: true,
+    });
+    const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+    try {
+      const hab = hby.makeHab("flat", undefined, {
+        transferable: true,
+        icount: 2,
+        isith: ["1/2", "1/2"],
+        ncount: 2,
+        nsith: ["1/2", "1/2"],
+        toad: 0,
+      });
+      const document = generateBareDidDocument(runtime, didFor(hab.pre));
+      const methods = verificationMethodMap(document);
+      const keyMethods = hab.kever!.verfers.map((verfer) => `#${verfer.qb64}`);
+      const root = requireVerificationMethod(methods, `#${hab.pre}`);
+
+      assertEquals(root.type, "ConditionalProof2022");
+      assertEquals(root.threshold, 2);
+      assertEquals(root.conditionWeightedThreshold, [
+        { condition: keyMethods[0], weight: 1 },
+        { condition: keyMethods[1], weight: 1 },
+      ]);
+      assertConditionalProofMethods(document);
+    } finally {
+      yield* runtime.close();
+      yield* hby.close(true);
+    }
+  });
+});
+
+Deno.test("did/webs - nested weighted thresholds project recursively without path fields", async () => {
+  await run(function*() {
+    const hby = yield* createHabery({
+      name: `did-webs-nested-weighted-${crypto.randomUUID()}`,
+      temp: true,
+    });
+    const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+    try {
+      const hab = hby.makeHab("nested", undefined, {
+        transferable: true,
+        icount: 3,
+        isith: [{ "1": ["1/2", "1/2"] }, "1"],
+        ncount: 3,
+        nsith: [{ "1": ["1/2", "1/2"] }, "1"],
+        toad: 0,
+      });
+      const document = generateBareDidDocument(runtime, didFor(hab.pre));
+      const methods = verificationMethodMap(document);
+      const keyMethods = hab.kever!.verfers.map((verfer) => `#${verfer.qb64}`);
+      const root = requireVerificationMethod(methods, `#${hab.pre}`);
+      const childId = `#${hab.pre}-kt-c0-g0`;
+      const child = requireVerificationMethod(methods, childId);
+
+      assertEquals(root.type, "ConditionalProof2022");
+      assertEquals(root.threshold, 1);
+      assertEquals(root.conditionWeightedThreshold, [
+        { condition: childId, weight: 1 },
+        { condition: keyMethods[2], weight: 1 },
+      ]);
+      assertEquals(child.type, "ConditionalProof2022");
+      assertEquals(child.threshold, 2);
+      assertEquals(child.conditionWeightedThreshold, [
+        { condition: keyMethods[0], weight: 1 },
+        { condition: keyMethods[1], weight: 1 },
+      ]);
+      assertConditionalProofMethods(document);
+    } finally {
+      yield* runtime.close();
+      yield* hby.close(true);
+    }
+  });
+});
+
+Deno.test("did/webs - multi-clause weighted thresholds project as conditionAnd children", async () => {
+  await run(function*() {
+    const hby = yield* createHabery({
+      name: `did-webs-multi-clause-${crypto.randomUUID()}`,
+      temp: true,
+    });
+    const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+    try {
+      const hab = hby.makeHab("multi", undefined, {
+        transferable: true,
+        icount: 4,
+        isith: [["1/2", "1/2"], ["1/2", "1/2"]],
+        ncount: 4,
+        nsith: [["1/2", "1/2"], ["1/2", "1/2"]],
+        toad: 0,
+      });
+      const document = generateBareDidDocument(runtime, didFor(hab.pre));
+      const methods = verificationMethodMap(document);
+      const keyMethods = hab.kever!.verfers.map((verfer) => `#${verfer.qb64}`);
+      const root = requireVerificationMethod(methods, `#${hab.pre}`);
+      const first = requireVerificationMethod(methods, `#${hab.pre}-kt-c0`);
+      const second = requireVerificationMethod(methods, `#${hab.pre}-kt-c1`);
+
+      assertEquals(root.type, "ConditionalProof2022");
+      assertEquals(root.conditionAnd, [`#${hab.pre}-kt-c0`, `#${hab.pre}-kt-c1`]);
+      assertEquals("threshold" in root, false);
+      assertEquals(first.threshold, 2);
+      assertEquals(first.conditionWeightedThreshold, [
+        { condition: keyMethods[0], weight: 1 },
+        { condition: keyMethods[1], weight: 1 },
+      ]);
+      assertEquals(second.threshold, 2);
+      assertEquals(second.conditionWeightedThreshold, [
+        { condition: keyMethods[2], weight: 1 },
+        { condition: keyMethods[3], weight: 1 },
+      ]);
+      assertConditionalProofMethods(document);
     } finally {
       yield* runtime.close();
       yield* hby.close(true);

--- a/packages/tufa/src/cli/command-definitions/tooling.ts
+++ b/packages/tufa/src/cli/command-definitions/tooling.ts
@@ -88,6 +88,11 @@ function registerDbCmds(program: Command, dispatch: CommandDispatch): void {
       .option("-t, --temp", "Use temporary database")
       .option("--compat", "Open KERIpy-compatible .keri stores instead of .tufa")
       .option(
+        "--map-size <bytes>",
+        "LMDB map size override in bytes (also honors KERI_LMDB_MAP_SIZE / KERI_BASER_MAP_SIZE; auto-adapts to existing data.mdb)",
+        (value: string) => Number.parseInt(value, 10),
+      )
+      .option(
         "--prefix <prefix>",
         "Logical key prefix filter for one sub-database target",
       )
@@ -109,6 +114,7 @@ function registerDbCmds(program: Command, dispatch: CommandDispatch): void {
           headDir?: string;
           temp?: boolean;
           compat?: boolean;
+          mapSize?: number;
           prefix?: string;
           limit?: number;
         },
@@ -118,6 +124,7 @@ function registerDbCmds(program: Command, dispatch: CommandDispatch): void {
         headDirPath: options.headDir,
         temp: options.temp || false,
         compat: options.compat || false,
+        mapSize: options.mapSize,
         target,
         prefix: options.prefix,
         limit: options.limit,

--- a/packages/tufa/test/integration/multisig-nested.test.ts
+++ b/packages/tufa/test/integration/multisig-nested.test.ts
@@ -1,0 +1,531 @@
+// @file-test-lane app-stateful-a
+
+import { action, type Operation, run, spawn } from "effection";
+import { assertEquals, assertExists } from "jsr:@std/assert";
+import {
+  createAgentRuntime,
+  createHabery,
+  EndpointRoles,
+  generateDidWebsArtifacts,
+  ingestKeriBytes,
+  processRuntimeTurn,
+  runAgentRuntime,
+} from "keri-ts/runtime";
+import { startServer } from "../../src/host/http-server.ts";
+import {
+  reserveTcpPort,
+  runTufa,
+  type SpawnedChild,
+  spawnTufa,
+  waitForServer,
+  waitForTaskHalt,
+} from "../test-helpers.ts";
+
+interface StoreSpec {
+  readonly name: string;
+  readonly headDirPath: string;
+  readonly alias: string;
+  readonly pre: string;
+}
+
+interface CmdResult {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface MailboxProvider {
+  readonly name: string;
+  readonly headDirPath: string;
+  readonly alias: string;
+  readonly pre: string;
+  readonly url: string;
+  readonly loc: Uint8Array;
+}
+
+Deno.test("tufa/multisig - nested weighted group inception joins without the third member and projects DID Webs", async () => {
+  const headRoot = await Deno.makeTempDir({ prefix: "tufa-nested-multisig-" });
+  try {
+    const providerPort = reserveTcpPort();
+    const providerUrl = `http://127.0.0.1:${providerPort}`;
+    const provider = await seedMailboxProvider(headRoot, providerUrl);
+    const alice = await initAndInceptMember(headRoot, "alice");
+    const bob = await initAndInceptMember(headRoot, "bob");
+    const carol = await initAndInceptMember(headRoot, "carol");
+    const stores = [alice, bob, carol];
+
+    await seedMailboxAndPeerState(stores, provider);
+
+    await run(function*(): Operation<void> {
+      const providerHby = yield* createHabery({
+        name: provider.name,
+        headDirPath: provider.headDirPath,
+        skipConfig: true,
+      });
+      const providerRuntime = yield* createAgentRuntime(providerHby, { mode: "indirect" });
+      const providerHab = providerHby.habByName(provider.alias);
+      const runtimeTask = yield* spawn(function*() {
+        yield* runAgentRuntime(providerRuntime, { hab: providerHab ?? undefined });
+      });
+      const serverTask = yield* spawn(function*() {
+        yield* startServer(providerPort, undefined, providerRuntime);
+      });
+
+      try {
+        yield* waitForServer(providerPort);
+
+        const groupConfig = `${headRoot}/group-incept.json`;
+        yield* waitForPromise(writeJson(groupConfig, {
+          aids: stores.map((store) => store.pre),
+          rmids: stores.map((store) => store.pre),
+          isith: [{ "1": ["1/2", "1/2"] }, "1"],
+          nsith: [{ "1": ["1/2", "1/2"] }, "1"],
+          toad: 0,
+        }));
+
+        const incept = yield* waitForPromise(runProposalWithJoin(
+          [
+            "multisig",
+            "incept",
+            "--name",
+            alice.name,
+            "--head-dir",
+            alice.headDirPath,
+            "--alias",
+            alice.alias,
+            "--group",
+            "team",
+            "--file",
+            groupConfig,
+            "--approval-timeout",
+            "12",
+          ],
+          bob,
+          "team",
+        ));
+        const inceptStatus = parseLastJson(incept.proposer.stdout);
+        const groupPre = stringField(inceptStatus, "group");
+        assertExists(groupPre);
+        assertEquals(inceptStatus.accepted, true);
+        assertEquals(parseLastJson(incept.joiner.stdout).accepted, true);
+
+        const interact = yield* waitForPromise(runProposalWithJoin(
+          [
+            "multisig",
+            "interact",
+            "--name",
+            alice.name,
+            "--head-dir",
+            alice.headDirPath,
+            "--group",
+            "team",
+            "--data",
+            "{\"nested\":\"ixn\"}",
+          ],
+          bob,
+          "team",
+        ));
+        assertEquals(parseLastJson(interact.proposer.stdout).accepted, true);
+        assertEquals(parseLastJson(interact.joiner.stdout).accepted, true);
+
+        const rpy = yield* waitForPromise(runProposalWithJoin(
+          [
+            "multisig",
+            "rpy",
+            "--name",
+            alice.name,
+            "--head-dir",
+            alice.headDirPath,
+            "--group",
+            "team",
+            "--eid",
+            provider.pre,
+            "--role",
+            "mailbox",
+            "--approval-timeout",
+            "12",
+          ],
+          bob,
+          "team",
+        ));
+        assertEquals(parseLastJson(rpy.proposer.stdout).accepted, true);
+        assertEquals(parseLastJson(rpy.joiner.stdout).accepted, true);
+
+        const dwsPort = reserveTcpPort();
+        const did = `did:webs:127.0.0.1%3A${dwsPort}:dws:${groupPre}`;
+        const webRoot = `${headRoot}/web-root`;
+        yield* waitForPromise(writeDidWebsArtifacts(alice, did, webRoot));
+        const dwsHby = yield* createHabery({
+          name: `dws-resolver-${crypto.randomUUID()}`,
+          headDirPath: `${headRoot}/dws-resolver`,
+          skipConfig: true,
+        });
+        const dwsRuntime = yield* createAgentRuntime(dwsHby, { mode: "local" });
+        const dwsServerTask = yield* spawn(function*() {
+          yield* startServer(dwsPort, undefined, dwsRuntime, {
+            dwsStaticFilesDir: webRoot,
+            dwsDidPath: "dws",
+            dwsInsecureHttp: true,
+          });
+        });
+        try {
+          yield* waitForServer(dwsPort);
+          const document = yield* fetchJson(`http://127.0.0.1:${dwsPort}/dws/${groupPre}/did.json`);
+          assertNestedConditionalProof(document, groupPre);
+        } finally {
+          yield* waitForTaskHalt(dwsServerTask, 100);
+          yield* dwsRuntime.close();
+          yield* dwsHby.close(true);
+        }
+      } finally {
+        yield* waitForTaskHalt(serverTask, 100);
+        yield* waitForTaskHalt(runtimeTask, 100);
+        yield* providerRuntime.close();
+        yield* providerHby.close();
+      }
+    });
+  } finally {
+    await Deno.remove(headRoot, { recursive: true }).catch(() => undefined);
+  }
+});
+
+async function seedMailboxProvider(headRoot: string, url: string): Promise<MailboxProvider> {
+  const name = `mailbox-provider-${crypto.randomUUID()}`;
+  const headDirPath = `${headRoot}/provider`;
+  const alias = "mailbox";
+  let pre = "";
+  let loc = new Uint8Array();
+
+  await run(function*(): Operation<void> {
+    const hby = yield* createHabery({ name, headDirPath, skipConfig: true });
+    const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+    try {
+      const hab = hby.makeHab(alias, undefined, {
+        transferable: false,
+        icount: 1,
+        isith: "1",
+        toad: 0,
+      });
+      pre = hab.pre;
+      loc = new Uint8Array(hab.makeLocScheme(url, hab.pre, "http"));
+      ingestKeriBytes(runtime, loc);
+      ingestKeriBytes(runtime, hab.makeEndRole(hab.pre, EndpointRoles.controller, true));
+      ingestKeriBytes(runtime, hab.makeEndRole(hab.pre, EndpointRoles.mailbox, true));
+      yield* processRuntimeTurn(runtime, { hab, pollMailbox: false });
+    } finally {
+      yield* runtime.close();
+      yield* hby.close();
+    }
+  });
+
+  return { name, headDirPath, alias, pre, url, loc };
+}
+
+async function initAndInceptMember(headRoot: string, alias: string): Promise<StoreSpec> {
+  const name = `member-${alias}-${crypto.randomUUID()}`;
+  const headDirPath = `${headRoot}/${alias}`;
+  const init = await runTufa([
+    "init",
+    "--name",
+    name,
+    "--head-dir",
+    headDirPath,
+    "--nopasscode",
+  ]);
+  assertCommandOk(init, `init ${alias}`);
+
+  const incept = await runTufa([
+    "incept",
+    "--name",
+    name,
+    "--head-dir",
+    headDirPath,
+    "--alias",
+    alias,
+    "--transferable",
+    "--icount",
+    "1",
+    "--isith",
+    "1",
+    "--ncount",
+    "1",
+    "--nsith",
+    "1",
+    "--toad",
+    "0",
+  ]);
+  assertCommandOk(incept, `incept ${alias}`);
+
+  return { name, headDirPath, alias, pre: extractPrefix(incept.stdout) };
+}
+
+async function seedMailboxAndPeerState(
+  stores: readonly StoreSpec[],
+  provider: MailboxProvider,
+): Promise<void> {
+  const providerKel = await clonePreMessages(provider.name, provider.headDirPath, provider.pre);
+  const memberKels = await Promise.all(
+    stores.map((store) => clonePreMessages(store.name, store.headDirPath, store.pre)),
+  );
+  const mailboxReplies = await Promise.all(
+    stores.map((store) => issueMailboxRole(store, provider, providerKel)),
+  );
+  const shared = [
+    ...providerKel,
+    provider.loc,
+    ...memberKels.flat(),
+    ...mailboxReplies,
+  ];
+  await Promise.all([
+    ...stores.map((store) => ingestSharedState(store.name, store.headDirPath, store.alias, shared)),
+    ingestSharedState(provider.name, provider.headDirPath, provider.alias, shared),
+  ]);
+}
+
+async function clonePreMessages(
+  name: string,
+  headDirPath: string,
+  pre: string,
+): Promise<Uint8Array[]> {
+  const messages: Uint8Array[] = [];
+  await run(function*(): Operation<void> {
+    const hby = yield* createHabery({ name, headDirPath, skipConfig: true });
+    try {
+      messages.push(...hby.db.clonePreIter(pre));
+    } finally {
+      yield* hby.close();
+    }
+  });
+  return messages;
+}
+
+async function issueMailboxRole(
+  store: StoreSpec,
+  provider: MailboxProvider,
+  providerKel: readonly Uint8Array[],
+): Promise<Uint8Array> {
+  let reply = new Uint8Array();
+  await run(function*(): Operation<void> {
+    const hby = yield* createHabery({
+      name: store.name,
+      headDirPath: store.headDirPath,
+      skipConfig: true,
+    });
+    const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+    try {
+      for (const message of providerKel) {
+        ingestKeriBytes(runtime, message);
+      }
+      ingestKeriBytes(runtime, provider.loc);
+      yield* processRuntimeTurn(runtime, { pollMailbox: false });
+      const hab = hby.habByName(store.alias);
+      assertExists(hab);
+      reply = new Uint8Array(hab.makeEndRole(provider.pre, EndpointRoles.mailbox, true));
+      ingestKeriBytes(runtime, reply);
+      yield* processRuntimeTurn(runtime, { hab, pollMailbox: false });
+    } finally {
+      yield* runtime.close();
+      yield* hby.close();
+    }
+  });
+  return reply;
+}
+
+async function ingestSharedState(
+  name: string,
+  headDirPath: string,
+  alias: string,
+  messages: readonly Uint8Array[],
+): Promise<void> {
+  await run(function*(): Operation<void> {
+    const hby = yield* createHabery({ name, headDirPath, skipConfig: true });
+    const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+    try {
+      const hab = hby.habByName(alias);
+      for (const message of messages) {
+        ingestKeriBytes(runtime, message);
+      }
+      yield* processRuntimeTurn(runtime, { hab: hab ?? undefined, pollMailbox: false });
+    } finally {
+      yield* runtime.close();
+      yield* hby.close();
+    }
+  });
+}
+
+async function runProposalWithJoin(
+  proposerArgs: string[],
+  joiner: StoreSpec,
+  group: string,
+): Promise<{ proposer: CmdResult; joiner: CmdResult }> {
+  const child = spawnTufa(proposerArgs);
+  await delay(750);
+  const joined = await runTufa([
+    "multisig",
+    "join",
+    "--name",
+    joiner.name,
+    "--head-dir",
+    joiner.headDirPath,
+    "--group",
+    group,
+    "--auto",
+    "--poll-turns",
+    "32",
+    "--poll-budget-ms",
+    "500",
+  ]);
+  assertCommandOk(joined, `join ${group}`);
+  const proposed = await waitForChild(child, 20_000);
+  assertCommandOk(proposed, proposerArgs.join(" "));
+  return { proposer: proposed, joiner: joined };
+}
+
+async function writeDidWebsArtifacts(
+  store: StoreSpec,
+  did: string,
+  outputDir: string,
+): Promise<void> {
+  await run(function*(): Operation<void> {
+    const hby = yield* createHabery({
+      name: store.name,
+      headDirPath: store.headDirPath,
+      skipConfig: true,
+    });
+    const runtime = yield* createAgentRuntime(hby, { mode: "local" });
+    try {
+      const artifacts = generateDidWebsArtifacts(runtime, {
+        alias: "team",
+        did,
+      });
+      const artifactDir = `${outputDir}/dws/${did.split(":").at(-1)}`;
+      Deno.mkdirSync(artifactDir, { recursive: true });
+      Deno.writeFileSync(`${artifactDir}/did.json`, artifacts.didJson);
+      Deno.writeFileSync(`${artifactDir}/keri.cesr`, artifacts.keriCesr);
+    } finally {
+      yield* runtime.close();
+      yield* hby.close();
+    }
+  });
+}
+
+function assertNestedConditionalProof(document: unknown, groupPre: string): void {
+  if (!document || typeof document !== "object") {
+    throw new Error("Expected DID document object.");
+  }
+  const methods = (document as { verificationMethod?: unknown }).verificationMethod;
+  if (!Array.isArray(methods)) {
+    throw new Error("Expected DID verificationMethod array.");
+  }
+  const byId = new Map(methods.map((method) => {
+    if (!method || typeof method !== "object" || typeof (method as { id?: unknown }).id !== "string") {
+      throw new Error("Expected verification method id.");
+    }
+    return [(method as { id: string }).id, method as Record<string, unknown>];
+  }));
+  const root = byId.get(`#${groupPre}`);
+  const child = byId.get(`#${groupPre}-kt-c0-g0`);
+  assertExists(root);
+  assertExists(child);
+  assertEquals(root.type, "ConditionalProof2022");
+  assertEquals(root.threshold, 1);
+  assertEquals(root.conditionWeightedThreshold, [
+    { condition: `#${groupPre}-kt-c0-g0`, weight: 1 },
+    { condition: rootKeyAt(methods, 2), weight: 1 },
+  ]);
+  assertEquals("path" in root, false);
+  assertEquals(child.type, "ConditionalProof2022");
+  assertEquals(child.threshold, 2);
+  assertEquals("path" in child, false);
+}
+
+function rootKeyAt(methods: readonly unknown[], index: number): string {
+  const keys = methods
+    .filter((method): method is { id: string; type?: string } =>
+      !!method && typeof method === "object" && typeof (method as { id?: unknown }).id === "string"
+    )
+    .filter((method) => method.type === "JsonWebKey")
+    .map((method) => method.id);
+  const key = keys[index];
+  if (!key) {
+    throw new Error(`Expected key method at index ${index}.`);
+  }
+  return key;
+}
+
+async function waitForChild(child: SpawnedChild, timeoutMs: number): Promise<CmdResult> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const status = await Promise.race([
+      child.status,
+      new Promise<Deno.CommandStatus>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error("command timed out")), timeoutMs);
+      }),
+    ]);
+    const [stdout, stderr] = await Promise.all([
+      child.stdout ? new Response(child.stdout).text() : Promise.resolve(""),
+      child.stderr ? new Response(child.stderr).text() : Promise.resolve(""),
+    ]);
+    return { code: status.code, stdout, stderr };
+  } catch (error) {
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // It may have exited between the timeout and kill.
+    }
+    throw error;
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+function assertCommandOk(result: CmdResult, label: string): void {
+  assertEquals(result.code, 0, `${label}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+}
+
+function parseLastJson(output: string): Record<string, unknown> {
+  const line = output.trim().split(/\r?\n/).reverse().find((candidate) => candidate.trim().startsWith("{"));
+  if (!line) {
+    throw new Error(`No JSON line in output:\n${output}`);
+  }
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Expected string field ${key}.`);
+  }
+  return value;
+}
+
+function extractPrefix(output: string): string {
+  const line = output.split(/\r?\n/).find((candidate) => candidate.trim().startsWith("Prefix"));
+  if (!line) {
+    throw new Error(`Unable to parse prefix from output:\n${output}`);
+  }
+  return line.trim().split(/\s+/).at(-1) ?? "";
+}
+
+function writeJson(path: string, value: unknown): Promise<void> {
+  return Deno.writeTextFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function* waitForPromise<T>(promise: Promise<T>): Operation<T> {
+  return yield* action((resolve, reject) => {
+    promise.then(resolve, reject);
+    return () => {};
+  });
+}
+
+function* fetchJson(url: string): Operation<unknown> {
+  const response = yield* waitForPromise(fetch(url));
+  assertEquals(response.status, 200);
+  return yield* waitForPromise(response.json());
+}


### PR DESCRIPTION
## Summary

- Support nested weighted multisig thresholds end to end: normalize Tufa inception-file inputs, preserve accepted EXN signature groups, and commit group-member metadata only after KEL acceptance.
- Project numeric, flat weighted, nested weighted, and multi-clause thresholds into recursive `ConditionalProof2022` DID Webs verification methods.
- Size LMDB mappings from explicit options, KERIpy-compatible environment variables, and existing `data.mdb` metadata; expose `tufa db dump --map-size` for large compatibility stores.
- Refresh canonical workspace paths and the corresponding maintainer learnings.

## Validation

- Focused CESR, KERI DB/app/DID Webs, and Tufa unit and integration tests pass, including the new public nested-multisig workflow without the unnecessary third signature.
- `deno task fmt:check` and `deno task changeset:check` pass.
- The broad `deno task quality` run reaches interop parity, where the existing KLI query scenario remains at sequence 0; the identical failure reproduces on unchanged `origin/master`, so it is not introduced by this PR.

## Release impact

Release-impacting patch changesets are included for `keri-ts` and `@keri-ts/tufa`.
